### PR TITLE
Add tests for text colouring (send_thinking & send_tool_status hooks)

### DIFF
--- a/tests/test_agent_thinking_tools_hooks.py
+++ b/tests/test_agent_thinking_tools_hooks.py
@@ -1,0 +1,276 @@
+"""Tests for agent firing send_thinking and send_tool_status hooks."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from corvidae.agent_loop import AgentTurnResult
+from corvidae.channel import ChannelConfig, ChannelRegistry
+from corvidae.persistence import PersistencePlugin, init_db
+from corvidae.hooks import create_plugin_manager
+from corvidae.task import TaskPlugin
+
+from helpers import build_plugin_and_channel, drain, drain_task_queue
+
+
+# ---------------------------------------------------------------------------
+# Response helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_text_response(text: str, reasoning: str | None = None) -> dict:
+    msg = {"role": "assistant", "content": text}
+    if reasoning is not None:
+        msg["reasoning_content"] = reasoning
+    return {"choices": [{"message": msg}]}
+
+
+def _make_tool_call_response(calls: list[dict]) -> dict:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": calls,
+                }
+            }
+        ]
+    }
+
+
+def _make_tool_call(call_id: str, name: str, args: dict) -> dict:
+    return {
+        "id": call_id,
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# send_thinking hook
+# ---------------------------------------------------------------------------
+
+
+class TestSendThinkingHook:
+    async def test_fired_when_reasoning_content_present(self):
+        """Agent fires send_thinking when LLM response includes reasoning_content."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        # Mock send_thinking to track calls
+        plugin.pm.ahook.send_thinking = AsyncMock()
+
+        # Mock LLM to return reasoning_content
+        reasoning_text = "I need to think about this carefully"
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(
+            return_value=_make_text_response("Here is my answer", reasoning=reasoning_text)
+        )
+        plugin._client = mock_client
+        plugin._tools = {}
+        plugin._tool_schemas = []
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="hello")
+        await drain(plugin, channel)
+
+        plugin.pm.ahook.send_thinking.assert_awaited_once_with(
+            channel=channel,
+            text=reasoning_text,
+        )
+        await db.close()
+
+    async def test_not_fired_when_no_reasoning_content(self):
+        """Agent does not fire send_thinking when LLM response has no reasoning_content."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        plugin.pm.ahook.send_thinking = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(
+            return_value=_make_text_response("Just a plain answer")
+        )
+        plugin._client = mock_client
+        plugin._tools = {}
+        plugin._tool_schemas = []
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="hello")
+        await drain(plugin, channel)
+
+        plugin.pm.ahook.send_thinking.assert_not_awaited()
+        await db.close()
+
+    async def test_failure_does_not_break_agent(self):
+        """If send_thinking hook raises, the agent still delivers the response."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        plugin.pm.ahook.send_thinking = AsyncMock(side_effect=RuntimeError("boom"))
+
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(
+            return_value=_make_text_response("My answer", reasoning="some thinking")
+        )
+        plugin._client = mock_client
+        plugin._tools = {}
+        plugin._tool_schemas = []
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="hello")
+        await drain(plugin, channel)
+
+        # Response should still be delivered via send_message
+        plugin.pm.ahook.send_message.assert_awaited_once()
+        call_kwargs = plugin.pm.ahook.send_message.call_args[1]
+        assert "My answer" in call_kwargs["text"]
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# send_tool_status hook
+# ---------------------------------------------------------------------------
+
+
+class TestSendToolStatusHook:
+    async def test_dispatched_fired_on_tool_call(self):
+        """Agent fires send_tool_status(dispatched) when LLM requests a tool call."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        plugin.pm.ahook.send_tool_status = AsyncMock()
+
+        tool_call = _make_tool_call("tc1", "shell", {"command": "echo hi"})
+
+        plugin._client = MagicMock()
+        plugin._client.chat = AsyncMock(
+            return_value=_make_tool_call_response([tool_call])
+        )
+
+        # Register the tool
+        async def fake_shell(command, **kwargs):
+            return "hi"
+
+        plugin._tools = {"shell": fake_shell}
+        plugin._tool_schemas = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ]
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="run echo")
+        await drain(plugin, channel)
+        await drain_task_queue(plugin)
+
+        # Check dispatched was called
+        dispatched_calls = [
+            c for c in plugin.pm.ahook.send_tool_status.call_args_list
+            if c[1].get("status") == "dispatched"
+        ]
+        assert len(dispatched_calls) == 1
+        assert dispatched_calls[0][1]["tool_name"] == "shell"
+        assert dispatched_calls[0][1]["args_summary"] is not None
+        await db.close()
+
+    async def test_dispatched_failure_does_not_break_agent(self):
+        """If send_tool_status raises on dispatch, tool still gets enqueued."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        plugin.pm.ahook.send_tool_status = AsyncMock(side_effect=RuntimeError("boom"))
+
+        tool_call = _make_tool_call("tc1", "shell", {"command": "echo hi"})
+
+        plugin._client = MagicMock()
+        plugin._client.chat = AsyncMock(
+            return_value=_make_tool_call_response([tool_call])
+        )
+
+        async def fake_shell(command, **kwargs):
+            return "hi"
+
+        plugin._tools = {"shell": fake_shell}
+        plugin._tool_schemas = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ]
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="run echo")
+        await drain(plugin, channel)
+        await drain_task_queue(plugin)
+
+        # Tool should still have been dispatched — task queue should drain
+        # without error
+        await db.close()
+
+    async def test_completed_fired_on_tool_result(self):
+        """send_tool_status(completed) fires when tool result is delivered."""
+        plugin, channel, db = await build_plugin_and_channel()
+
+        plugin.pm.ahook.send_tool_status = AsyncMock()
+
+        tool_call = _make_tool_call("tc1", "shell", {"command": "echo hi"})
+
+        # First call: tool call. Second call: text response after tool result.
+        plugin._client = MagicMock()
+        plugin._client.chat = AsyncMock(
+            side_effect=[
+                _make_tool_call_response([tool_call]),
+                _make_text_response("Done!"),
+            ]
+        )
+
+        async def fake_shell(command, **kwargs):
+            return "hi"
+
+        plugin._tools = {"shell": fake_shell}
+        plugin._tool_schemas = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ]
+        plugin._max_tool_result_chars = 10000
+
+        await plugin.pm.ahook.on_message(channel=channel, sender="user", text="run echo")
+        await drain(plugin, channel)
+        await drain_task_queue(plugin)
+        await drain(plugin, channel)  # drain again for the tool-result turn
+
+        # Check completed was called
+        completed_calls = [
+            c for c in plugin.pm.ahook.send_tool_status.call_args_list
+            if c[1].get("status") == "completed"
+        ]
+        assert len(completed_calls) == 1
+        assert completed_calls[0][1]["tool_name"] == "shell"
+        assert completed_calls[0][1]["result_summary"] is not None
+        await db.close()

--- a/tests/test_cli_thinking_tools.py
+++ b/tests/test_cli_thinking_tools.py
@@ -1,0 +1,191 @@
+"""Tests for CLIPlugin send_thinking and send_tool_status hooks."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from corvidae.channel import ChannelRegistry
+from corvidae.hooks import create_plugin_manager
+from corvidae.channels.cli import CLIPlugin
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+AGENT_DEFAULTS = {
+    "system_prompt": "You are a test assistant.",
+    "max_context_tokens": 8000,
+    "keep_thinking_in_history": False,
+}
+
+
+def _make_cli_plugin():
+    """Create a CLIPlugin with a cli:local channel registered."""
+    pm = create_plugin_manager()
+    registry = ChannelRegistry(AGENT_DEFAULTS)
+    pm.register(registry, name="registry")
+    pm.ahook.on_message = AsyncMock()
+    pm.ahook.send_message = AsyncMock()
+
+    channel = registry.get_or_create("cli", "local")
+    plugin = CLIPlugin(pm)
+    pm.register(plugin, name="cli")
+    return plugin, channel
+
+
+def _make_non_cli_channel():
+    """Create a plugin with an irc channel (not cli)."""
+    pm = create_plugin_manager()
+    registry = ChannelRegistry(AGENT_DEFAULTS)
+    pm.register(registry, name="registry")
+
+    channel = registry.get_or_create("irc", "#general")
+    plugin = CLIPlugin(pm)
+    pm.register(plugin, name="cli")
+    return plugin, channel
+
+
+# ---------------------------------------------------------------------------
+# send_thinking
+# ---------------------------------------------------------------------------
+
+
+class TestSendThinking:
+    async def test_cli_channel_prints_thinking_in_blue(self, capsys):
+        """send_thinking on a cli channel prints text in bright blue ANSI."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_thinking(channel=channel, text="I am reasoning about this")
+        captured = capsys.readouterr()
+        assert "I am reasoning about this" in captured.out
+        assert "\033[94m" in captured.out
+        assert "\033[0m" in captured.out
+
+    async def test_non_cli_channel_ignored(self, capsys):
+        """send_thinking on a non-cli channel produces no output."""
+        plugin, channel = _make_non_cli_channel()
+        await plugin.send_thinking(channel=channel, text="should not appear")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    async def test_long_thinking_truncated(self, capsys):
+        """send_thinking truncates text longer than 500 chars with '...'."""
+        plugin, channel = _make_cli_plugin()
+        long_text = "x" * 600
+        await plugin.send_thinking(channel=channel, text=long_text)
+        captured = capsys.readouterr()
+        assert "xxx..." in captured.out
+        # Should not contain the full 600 chars
+        assert "x" * 600 not in captured.out
+        # Should contain first 500 chars worth of content
+        assert "x" * 497 in captured.out  # 500 - 3 for "..."
+
+
+# ---------------------------------------------------------------------------
+# send_tool_status — dispatched
+# ---------------------------------------------------------------------------
+
+
+class TestSendToolStatusDispatched:
+    async def test_cli_channel_prints_dispatched_tool(self, capsys):
+        """send_tool_status dispatched on a cli channel prints in bright magenta with ⚙."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="dispatched",
+            args_summary='{"command": "ls"}',
+        )
+        captured = capsys.readouterr()
+        assert "⚙" in captured.out
+        assert "shell" in captured.out
+        assert "\033[95m" in captured.out
+        assert "\033[0m" in captured.out
+
+    async def test_dispatched_includes_args_summary(self, capsys):
+        """send_tool_status dispatched shows pretty-printed JSON args."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="read_file",
+            status="dispatched",
+            args_summary='{"path": "/tmp/test.txt"}',
+        )
+        captured = capsys.readouterr()
+        assert "read_file" in captured.out
+        assert "path" in captured.out
+
+    async def test_dispatched_without_args_summary(self, capsys):
+        """send_tool_status dispatched with no args_summary shows just the tool name."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="dispatched",
+            args_summary=None,
+        )
+        captured = capsys.readouterr()
+        assert "⚙" in captured.out
+        assert "shell" in captured.out
+
+    async def test_non_cli_channel_ignored(self, capsys):
+        """send_tool_status dispatched on a non-cli channel produces no output."""
+        plugin, channel = _make_non_cli_channel()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="dispatched",
+        )
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# send_tool_status — completed
+# ---------------------------------------------------------------------------
+
+
+class TestSendToolStatusCompleted:
+    async def test_cli_channel_prints_completed_tool(self, capsys):
+        """send_tool_status completed on a cli channel prints ✓ in bright magenta."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="completed",
+            result_summary="hello world",
+        )
+        captured = capsys.readouterr()
+        assert "✓" in captured.out
+        assert "shell" in captured.out
+        assert "hello world" in captured.out
+        assert "\033[95m" in captured.out
+
+    async def test_completed_without_result_summary(self, capsys):
+        """send_tool_status completed with no result_summary shows just ✓ and name."""
+        plugin, channel = _make_cli_plugin()
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="completed",
+            result_summary=None,
+        )
+        captured = capsys.readouterr()
+        assert "✓" in captured.out
+        assert "shell" in captured.out
+        assert "→" not in captured.out
+
+    async def test_completed_truncates_long_result(self, capsys):
+        """send_tool_status completed truncates result_summary to 80 chars."""
+        plugin, channel = _make_cli_plugin()
+        long_result = "x" * 200
+        await plugin.send_tool_status(
+            channel=channel,
+            tool_name="shell",
+            status="completed",
+            result_summary=long_result,
+        )
+        captured = capsys.readouterr()
+        assert "→" in captured.out
+        # Should not contain full 200-char result
+        assert "x" * 200 not in captured.out


### PR DESCRIPTION
## Summary

Tests for the coloured CLI output feature added in commits `2e604ff` and `e8bfa34`.

### What changed
- **16 new tests** across 2 test files covering the `send_thinking` and `send_tool_status` hooks
- **Bug fix in tests**: The original test code was setting `plugin._llm_client` (a nonexistent attribute) instead of `plugin._client` (the actual field `Agent.on_message` checks). This caused every agent-level test involving `reasoning_content` to hang because the agent returned early with `"LLM client not initialized"`.

### Test files
- `test_cli_thinking_tools.py` (10 tests): CLI rendering — ANSI colors, icons, truncation, non-CLI channel filtering
- `test_agent_thinking_tools_hooks.py` (6 tests): Agent integration — hooks are fired/not fired correctly, failures don't break the agent

### How to verify
```bash
uv run pytest tests/test_cli_thinking_tools.py tests/test_agent_thinking_tools_hooks.py -v
```

Full suite passes: 967 tests, 0 failures.