### PR TITLE
Improve default compaction prompts (Schuyler-style design)

### DIFF
--- a/corvidae/compaction.py
+++ b/corvidae/compaction.py
@@ -32,9 +32,12 @@ class CompactionPlugin:
     depends_on = {"llm"}
 
     DEFAULT_SUMMARY_PROMPT = (
-        "Summarize the following conversation concisely, "
-        "preserving key facts, decisions, and context that "
-        "would be needed to continue the conversation."
+        "Please summarize the first half of this conversation, so that the second half "
+        "flows naturally verbatim. The summary should include a high-level explanation of "
+        "what the agent was working on or attempting to achieve. The agent's next prompt "
+        "will contain your summary followed by the second half of the conversation to this point.\n\n"
+        "In 1000 words or less. Preserve specific details: file paths, variable names, "
+        "error messages, discoveries made, and the current line of investigation."
     )
 
     def __init__(self, pm) -> None:

--- a/corvidae/context_compact.py
+++ b/corvidae/context_compact.py
@@ -70,14 +70,12 @@ class ContextCompactPlugin:
     """
 
     DEFAULT_BG_BLOCK_PROMPT = (
-        "Generate a concise background context block from this "
-        "conversation history. Focus on:\n"
-        "- Key facts and decisions\n"
-        "- Current state and ongoing work\n"
-        "- Open questions or pending items\n"
-        "- Any constraints or preferences mentioned\n\n"
-        "Keep it under 2048 characters. Omit conversational filler; "
-        "preserve only information needed for future context."
+        "Summarize this conversation segment as a background context block. "
+        "The summary will be injected before future conversation turns to provide context.\n\n"
+        "Include a high-level explanation of what the agent was working on or attempting to achieve. "
+        "Preserve specific details: file paths, variable names, error messages, discoveries made, "
+        "and the current state of any ongoing work.\n\n"
+        "In 500 words or less. Omit conversational filler."
     )
 
     depends_on = {"compaction", "llm"}

--- a/tests/test_compaction_quality.py
+++ b/tests/test_compaction_quality.py
@@ -272,3 +272,28 @@ class TestConfigurablePrompts:
         """Sanity check: the default bg block prompt is substantive."""
         from corvidae.context_compact import ContextCompactPlugin
         assert len(ContextCompactPlugin.DEFAULT_BG_BLOCK_PROMPT) > 50
+
+
+class TestDefaultPromptDesign:
+    """Tests that the default prompts follow the Schuyler-style design principles."""
+
+    def test_default_prompt_mentions_flow_into_retained(self):
+        """Default prompt should instruct the LLM that its summary flows into retained context."""
+        prompt = CompactionPlugin.DEFAULT_SUMMARY_PROMPT.lower()
+        assert "second half" in prompt or "flows naturally" in prompt or "verbatim" in prompt
+
+    def test_default_prompt_has_word_limit(self):
+        """Default prompt should include a word/length limit."""
+        prompt = CompactionPlugin.DEFAULT_SUMMARY_PROMPT.lower()
+        assert "words" in prompt or "characters" in prompt or "limit" in prompt
+
+    def test_default_prompt_mentions_specific_details(self):
+        """Default prompt should instruct preservation of specific details."""
+        prompt = CompactionPlugin.DEFAULT_SUMMARY_PROMPT.lower()
+        assert "file path" in prompt or "variable" in prompt or "error" in prompt
+
+    def test_bg_block_prompt_has_word_limit(self):
+        """Background block prompt should include a word/length limit."""
+        from corvidae.context_compact import ContextCompactPlugin
+        prompt = ContextCompactPlugin.DEFAULT_BG_BLOCK_PROMPT.lower()
+        assert "words" in prompt or "characters" in prompt or "limit" in prompt


### PR DESCRIPTION
## What

Replaces the generic `"summarize concisely"` compaction prompts with structured prompts that give the LLM a clear understanding of its role in the context pipeline.

## Design (from Schuyler)

The key insight: tell the LLM that its summary needs to flow naturally into the retained verbatim context. This gives the LLM a *structural* understanding of what it's doing, rather than a fragile laundry list of things to preserve.

### CompactionPlugin summary prompt (default)
> Please summarize the first half of this conversation, so that the second half flows naturally verbatim. The summary should include a high-level explanation of what the agent was working on or attempting to achieve. The agent's next prompt will contain your summary followed by the second half of the conversation to this point.
>
> In 1000 words or less. Preserve specific details: file paths, variable names, error messages, discoveries made, and the current line of investigation.

### ContextCompactPlugin background block prompt (default)
> Summarize this conversation segment as a background context block. The summary will be injected before future conversation turns to provide context.
>
> Include a high-level explanation of what the agent was working on or attempting to achieve. Preserve specific details: file paths, variable names, error messages, discoveries made, and the current state of any ongoing work.
>
> In 500 words or less. Omit conversational filler.

## Changes
- New `DEFAULT_SUMMARY_PROMPT` class attribute on `CompactionPlugin`
- New `DEFAULT_BG_BLOCK_PROMPT` class attribute on `ContextCompactPlugin`
- Both remain fully overridable via `agent.yaml` config (from PR #3)
- 4 new tests verifying the design principles (flow, word limit, specific details)

## Depends on
- **PR #3** (guardrails + configurable prompts infrastructure)

## How to verify
```bash
uv run pytest tests/test_compaction_quality.py -v
```

Full suite: 971 passed, 0 failures.