### PR TITLE
Fix #9: Remove reasoning content truncation in CLI

### DIFF
--- a/corvidae/channels/cli.py
+++ b/corvidae/channels/cli.py
@@ -95,12 +95,10 @@ class CLIPlugin:
 
     @hookimpl
     async def send_thinking(self, channel, text: str) -> None:
-        """Display reasoning/thinking content in dim cyan."""
+        """Display reasoning/thinking content in bright blue."""
         if not channel.matches_transport("cli"):
             return
-        # Truncate for display if very long
-        display = text if len(text) <= 500 else text[:500] + "..."
-        print(f"\033[94m{display}\033[0m")
+        print(f"[94m{text}[0m")
         sys.stdout.flush()
 
     @hookimpl

--- a/tests/test_cli_thinking_tools.py
+++ b/tests/test_cli_thinking_tools.py
@@ -68,17 +68,15 @@ class TestSendThinking:
         captured = capsys.readouterr()
         assert captured.out == ""
 
-    async def test_long_thinking_truncated(self, capsys):
-        """send_thinking truncates text longer than 500 chars with '...'."""
+    async def test_long_thinking_not_truncated(self, capsys):
+        """send_thinking displays full reasoning content without truncation."""
         plugin, channel = _make_cli_plugin()
-        long_text = "x" * 600
+        long_text = "x" * 2000
         await plugin.send_thinking(channel=channel, text=long_text)
         captured = capsys.readouterr()
-        assert "xxx..." in captured.out
-        # Should not contain the full 600 chars
-        assert "x" * 600 not in captured.out
-        # Should contain first 500 chars worth of content
-        assert "x" * 497 in captured.out  # 500 - 3 for "..."
+        # Full content must appear — no truncation
+        assert long_text in captured.out
+        assert "..." not in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #9 — reasoning/thinking content displayed in the CLI was truncated to 500 characters with ellipsis.

## Changes

- ****: Removed the truncation logic from `send_thinking`. The full reasoning text is now passed through to `print()`.
- **`tests/test_cli_thinking_tools.py`**: Changed `test_long_thinking_truncated` → `test_long_thinking_not_truncated` asserting that a 2000-char string appears in full.

## TDD

1. **Red**: Changed test to assert no truncation → test failed (2000-char string not found in output with `...`)
2. **Green**: Removed truncation from `send_thinking` → test passed
3. **Refactor**: No further changes needed (removal was the refactor)

All 1002 tests pass.