### PR TITLE
Migrate plugin registration to setuptools entry points

### DIFF
--- a/corvidae/agent.py
+++ b/corvidae/agent.py
@@ -32,7 +32,7 @@ from enum import Enum
 from corvidae.agent_loop import AgentTurnResult, run_agent_turn
 from corvidae.channel import Channel, ChannelConfig, ChannelRegistry, resolve_system_prompt
 from corvidae.context import ContextWindow, MessageType, DEFAULT_CHARS_PER_TOKEN
-from corvidae.hooks import resolve_hook_results, HookStrategy, get_dependency, hookimpl
+from corvidae.hooks import CorvidaePlugin, resolve_hook_results, HookStrategy, get_dependency, hookimpl
 from corvidae.queue import SerialQueue
 from corvidae.task import Task
 from corvidae.tool import dispatch_tool_call
@@ -77,7 +77,7 @@ class QueueItem:
     meta: dict = field(default_factory=dict)
 
 
-class Agent:
+class Agent(CorvidaePlugin):
     """Plugin that wires the agent loop into the hook system.
 
     Attributes:
@@ -90,10 +90,11 @@ class Agent:
         _registry: ChannelRegistry, resolved in on_start via get_dependency
     """
 
-    depends_on = {"registry", "task", "llm", "tools"}
+    depends_on = frozenset({"registry", "task", "llm", "tools"})
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self._client = None
         self._tools: dict[str, Callable] = {}
         self._tool_schemas: list[dict] = []
@@ -145,6 +146,14 @@ class Agent:
             logger.warning("on_idle hook raised exception", exc_info=True)
         finally:
             self._idle_firing = False
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        agent_config = config.get("agent", {})
+        self._chars_per_token = agent_config.get("chars_per_token", DEFAULT_CHARS_PER_TOKEN)
+        daemon_config = config.get("daemon", {})
+        self._idle_cooldown = daemon_config.get("idle_cooldown_seconds", 30.0)
 
     async def on_start(self, config: dict) -> None:
         await self._start_plugin(config)
@@ -647,11 +656,7 @@ class Agent:
         self._registry = get_dependency(self.pm, "registry", ChannelRegistry)
         self._tools = {}
         self._tool_schemas = []
-        agent_config = config.get("agent", {})
-        self._chars_per_token = agent_config.get("chars_per_token", DEFAULT_CHARS_PER_TOKEN)
         self._base_dir = config.get("_base_dir", Path("."))
-        daemon_config = config.get("daemon", {})
-        self._idle_cooldown = daemon_config.get("idle_cooldown_seconds", 30.0)
 
         # Get the LLM client from LLMPlugin (which owns the lifecycle).
         llm = get_dependency(self.pm, "llm", LLMPlugin)

--- a/corvidae/channel.py
+++ b/corvidae/channel.py
@@ -116,13 +116,14 @@ class Channel:
 class ChannelRegistry:
     """Manages the lifecycle of channels."""
 
-    def __init__(self, agent_defaults: dict) -> None:
+    def __init__(self, agent_defaults: dict | None = None) -> None:
         """
         Args:
             agent_defaults: Agent-level config dict used as fallback when
-                resolving per-channel configuration overrides.
+                resolving per-channel configuration overrides. Defaults to {}
+                when not provided (no-arg construction for entry-point loading).
         """
-        self.agent_defaults = agent_defaults
+        self.agent_defaults = agent_defaults if agent_defaults is not None else {}
         self.channels: dict[str, Channel] = {}
 
     def get_or_create(

--- a/corvidae/channels/cli.py
+++ b/corvidae/channels/cli.py
@@ -7,22 +7,23 @@ import signal
 import sys
 
 from corvidae.channel import ChannelRegistry
-from corvidae.hooks import get_dependency, hookimpl
+from corvidae.hooks import CorvidaePlugin, get_dependency, hookimpl
 
 logger = logging.getLogger(__name__)
 
 
-class CLIPlugin:
+class CLIPlugin(CorvidaePlugin):
     """Transport plugin for stdin/stdout interaction.
 
     Implements on_start, send_message, and on_stop hooks. Only active when
     at least one cli channel is configured.
     """
 
-    depends_on = {"registry"}
+    depends_on = frozenset({"registry"})
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self._task: asyncio.Task | None = None
         self._registry: ChannelRegistry | None = None
 

--- a/corvidae/channels/irc.py
+++ b/corvidae/channels/irc.py
@@ -10,7 +10,7 @@ import pydle
 logger = logging.getLogger("corvidae.irc_plugin")
 
 from corvidae.channel import Channel, ChannelRegistry
-from corvidae.hooks import get_dependency, hookimpl
+from corvidae.hooks import CorvidaePlugin, get_dependency, hookimpl
 
 
 class IRCClient(pydle.Client):
@@ -83,18 +83,36 @@ class IRCClient(pydle.Client):
             raise
 
 
-class IRCPlugin:
+class IRCPlugin(CorvidaePlugin):
     """IRC transport plugin following CLIPlugin pattern."""
 
-    depends_on = {"registry"}
+    depends_on = frozenset({"registry"})
 
-    def __init__(self, pm):
-        self.pm = pm
+    def __init__(self, pm=None):
+        if pm is not None:
+            self.pm = pm
         self.client: Optional[IRCClient] = None
         self._connect_task: Optional[asyncio.Task] = None
         self.channels: list[str] = []
         self._registry: Optional[ChannelRegistry] = None
         self._message_chunk_size: int = 400
+        self._irc_server: str = "irc.libera.chat"
+        self._irc_port: int = 6667
+        self._irc_nick: str = "corvidae"
+        self._irc_tls: bool = False
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        irc_config = config.get("irc")
+        if irc_config is None:
+            return
+        self._irc_server = irc_config.get("host", "irc.libera.chat")
+        self._irc_port = irc_config.get("port", 6667)
+        self._irc_nick = irc_config.get("nick", "corvidae")
+        self.channels = irc_config.get("channels", [])
+        self._irc_tls = irc_config.get("tls", False)
+        self._message_chunk_size = irc_config.get("message_chunk_size", 400)
 
     @hookimpl
     async def on_start(self, config: dict) -> None:
@@ -103,14 +121,10 @@ class IRCPlugin:
         if irc_config is None:
             return
 
-        server = irc_config.get("host", "irc.libera.chat")
-        port = irc_config.get("port", 6667)
-        nick = irc_config.get("nick", "corvidae")
-        self.channels = irc_config.get("channels", [])
-        tls = irc_config.get("tls", False)
-        self._message_chunk_size = irc_config.get("message_chunk_size", 400)
-
-        self.client = IRCClient(self, nick, server=server, port=port, tls=tls)
+        self.client = IRCClient(
+            self, self._irc_nick,
+            server=self._irc_server, port=self._irc_port, tls=self._irc_tls,
+        )
         self._connect_task = asyncio.create_task(self.client.connect_with_retry())
 
     async def on_channel_message(self, target, by, message):

--- a/corvidae/compaction.py
+++ b/corvidae/compaction.py
@@ -21,15 +21,15 @@ import logging
 import time
 
 from corvidae.context import DEFAULT_CHARS_PER_TOKEN, MessageType
-from corvidae.hooks import get_dependency, hookimpl
+from corvidae.hooks import CorvidaePlugin, get_dependency, hookimpl
 
 logger = logging.getLogger(__name__)
 
 
-class CompactionPlugin:
+class CompactionPlugin(CorvidaePlugin):
     """Plugin that implements default token-budget conversation compaction."""
 
-    depends_on = {"llm"}
+    depends_on = frozenset({"llm"})
 
     DEFAULT_SUMMARY_PROMPT = (
         "Please summarize the first half of this conversation, so that the second half "
@@ -40,8 +40,8 @@ class CompactionPlugin:
         "error messages, discoveries made, and the current line of investigation."
     )
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        self.pm = pm  # May be None; on_init will set it via CorvidaePlugin.on_init
         self._compaction_threshold: float = 0.8
         self._compaction_retention: float = 0.5
         self._min_messages: int = 5
@@ -54,7 +54,8 @@ class CompactionPlugin:
         self._last_failed_compaction: dict[str, float] = {}  # channel_id -> timestamp
 
     @hookimpl
-    async def on_start(self, config: dict) -> None:
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
         agent_config = config.get("agent", {})
         self._compaction_threshold = agent_config.get("compaction_threshold", 0.8)
         self._compaction_retention = agent_config.get("compaction_retention", 0.5)

--- a/corvidae/hooks.py
+++ b/corvidae/hooks.py
@@ -203,6 +203,28 @@ def create_plugin_manager() -> pluggy.PluginManager:
     return pm
 
 
+class CorvidaePlugin:
+    """Optional base class for corvidae plugins.
+
+    Stores pm and config as instance attributes in on_init, making them
+    available before on_start is called. Plugins that need extra init
+    should override on_init and call ``await super().on_init(pm, config)``
+    first.
+
+    Class attribute:
+        depends_on: frozenset of plugin names this plugin requires to be
+            registered. Checked by validate_dependencies at startup.
+            Override as a class-level assignment, not by mutation.
+    """
+
+    depends_on: frozenset[str] = frozenset()
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        """Store pm and config. Called after all plugins are registered."""
+        self.pm = pm
+        self.config = config
+
 
 class AgentSpec:
     """Hook specifications for the agent daemon.
@@ -212,6 +234,18 @@ class AgentSpec:
     the agent loop. All hooks are optional; a plugin only needs to
     implement the hooks it cares about.
     """
+
+    @hookspec
+    async def on_init(self, pm, config: dict) -> None:
+        """Called after all plugins are registered, before on_start.
+
+        Use for storing pm, reading config values, and resolving references
+        to other plugins. Do not create runtime resources here — use on_start.
+
+        Args:
+            pm: The plugin manager.
+            config: The full parsed YAML config dict.
+        """
 
     @hookspec
     async def on_start(self, config: dict) -> None:

--- a/corvidae/idle.py
+++ b/corvidae/idle.py
@@ -8,18 +8,19 @@ all queues are empty and the cooldown has elapsed.
 
 import logging
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
 logger = logging.getLogger(__name__)
 
 
-class IdleMonitorPlugin:
+class IdleMonitorPlugin(CorvidaePlugin):
     """Pure consumer of the on_idle hook. Implements idle behaviors."""
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
 
     @hookimpl
     async def on_idle(self) -> None:

--- a/corvidae/jsonl_log.py
+++ b/corvidae/jsonl_log.py
@@ -16,12 +16,12 @@ import time
 from pathlib import Path
 from typing import IO
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
 logger = logging.getLogger(__name__)
 
 
-class JsonlLogPlugin:
+class JsonlLogPlugin(CorvidaePlugin):
     """Plugin that writes conversation events to per-channel JSONL files.
 
     Implements on_conversation_event and on_compaction hookimpls. Each
@@ -31,20 +31,27 @@ class JsonlLogPlugin:
     If ``jsonl_log_dir`` is not configured, the plugin is a complete no-op.
     """
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self._log_dir: Path | None = None
         self._handles: dict[str, IO] = {}  # channel_id -> open file handle
 
     @hookimpl
-    async def on_start(self, config: dict) -> None:
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
         log_dir = config.get("daemon", {}).get("jsonl_log_dir")
         if log_dir is None:
             return
         base_dir = config.get("_base_dir", Path("."))
         self._log_dir = Path(base_dir) / log_dir
+
+    @hookimpl
+    async def on_start(self, config: dict) -> None:
+        if self._log_dir is None:
+            return
         await asyncio.to_thread(self._log_dir.mkdir, parents=True, exist_ok=True)
         logger.info("JSONL log directory: %s", self._log_dir)
 

--- a/corvidae/llm_plugin.py
+++ b/corvidae/llm_plugin.py
@@ -20,30 +20,44 @@ Config:
 """
 import logging
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.llm import LLMClient
 
 logger = logging.getLogger(__name__)
 
 
-class LLMPlugin:
+class LLMPlugin(CorvidaePlugin):
     """Plugin that owns LLM client instances and their lifecycle."""
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self.main_client: LLMClient | None = None
         self.background_client: LLMClient | None = None
+        self._main_config: dict | None = None
+        self._bg_config: dict | None = None
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        llm_config = config.get("llm", {})
+        self._main_config = llm_config.get("main")
+        self._bg_config = llm_config.get("background")
 
     @hookimpl
     async def on_start(self, config: dict) -> None:
-        llm_config = config.get("llm", {})
-        main_config = llm_config["main"]  # required
+        main_config = self._main_config
+        if main_config is None:
+            # Backward compat: read from config if on_init was not called
+            main_config = config.get("llm", {}).get("main")
+        if main_config is None:
+            raise KeyError("llm.main config is required")
         self.main_client = self._create_client(main_config)
         await self.main_client.start()
 
-        bg_config = llm_config.get("background")
+        bg_config = self._bg_config
         if bg_config:
             self.background_client = self._create_client(bg_config)
             await self.background_client.start()

--- a/corvidae/main.py
+++ b/corvidae/main.py
@@ -15,25 +15,27 @@ Shutdown:
     signal is logged before plugins are stopped.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 import signal
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pluggy
 
 import yaml
 
-from corvidae.agent import Agent
 from corvidae.channel import ChannelRegistry, load_channel_config
-from corvidae.channels.cli import CLIPlugin
-from corvidae.channels.irc import IRCPlugin
 from corvidae.hooks import create_plugin_manager, validate_dependencies
 from corvidae.logging import StructuredFormatter  # noqa: F401 — re-exported
 from corvidae.logging import configure_logging
-from corvidae.tools import CoreToolsPlugin
+
+if TYPE_CHECKING:
+    from corvidae.agent import Agent
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +46,12 @@ async def main(config_path: str = "agent.yaml", *, cli_mode: bool = False) -> No
     1. Load YAML config from config_path. Raises FileNotFoundError if missing.
     2. Configure logging from config section or defaults.
     3. Create plugin manager via create_plugin_manager().
-    4. Call await pm.ahook.on_start(config=config).
-    5. Wait for SIGINT or SIGTERM.
-    6. Call await pm.ahook.on_stop().
+    4. Construct ChannelRegistry, load entry-point plugins.
+    5. Call await pm.ahook.on_init(pm=pm, config=config).
+    6. Call await pm.ahook.on_start(config=config).
+    7. Call await agent.on_start(config=config) explicitly (not via broadcast).
+    8. Wait for SIGINT or SIGTERM.
+    9. Call await pm.ahook.on_stop().
     """
     with open(config_path) as f:
         config = yaml.safe_load(f)
@@ -66,115 +71,24 @@ async def main(config_path: str = "agent.yaml", *, cli_mode: bool = False) -> No
     config["_base_dir"] = Path(config_path).parent
 
     pm = create_plugin_manager()
-    pm.load_setuptools_entrypoints("corvidae")
 
-    # Extract agent-level defaults for channel config resolution
-    agent_defaults = config.get("agent", {})
-    registry = ChannelRegistry(agent_defaults)
-
-    # Register registry as a named plugin so plugins access it
-    # via pm.get_plugin("registry") / get_dependency()
+    # ChannelRegistry is not an entry-point plugin — construct and register explicitly.
+    registry = ChannelRegistry()
     pm.register(registry, name="registry")
-
-    # Pre-register channels from YAML config (must happen before on_start)
+    registry.agent_defaults = config.get("agent", {})
     load_channel_config(config, registry)
 
-    # Register PersistencePlugin after registry, before other plugins
-    from corvidae.persistence import PersistencePlugin
-    persistence_plugin = PersistencePlugin(pm)
-    pm.register(persistence_plugin, name="persistence")
-
-    # Register JsonlLogPlugin after PersistencePlugin (observes conversation events)
-    from corvidae.jsonl_log import JsonlLogPlugin
-    jsonl_log_plugin = JsonlLogPlugin(pm)
-    pm.register(jsonl_log_plugin, name="jsonl_log")
-
-    # Register CoreToolsPlugin before Agent so tools are collected during on_start
-    core_tools = CoreToolsPlugin(pm)
-    pm.register(core_tools, name="core_tools")
-
-    # Register CLIPlugin before Agent (transport plugins first)
-    cli_plugin = CLIPlugin(pm)
-    pm.register(cli_plugin, name="cli")
-
-    # Register IRCPlugin before Agent (transport plugins first)
-    irc_plugin = IRCPlugin(pm)
-    pm.register(irc_plugin, name="irc")
-
-    # Register TaskPlugin before Agent (provides task queue)
-    from corvidae.task import TaskPlugin
-    task_plugin = TaskPlugin(pm)
-    pm.register(task_plugin, name="task")
-
-    # Register SubagentPlugin after TaskPlugin, before Agent
-    from corvidae.tools.subagent import SubagentPlugin
-    subagent_plugin = SubagentPlugin(pm)
-    pm.register(subagent_plugin, name="subagent")
-
-    # Register McpClientPlugin before Agent (provides MCP server tools)
-    from corvidae.mcp_client import McpClientPlugin
-    mcp_plugin = McpClientPlugin(pm)
-    pm.register(mcp_plugin, name="mcp")
-
-    # Register LLMPlugin before CompactionPlugin and Agent (owns LLM client lifecycle)
-    from corvidae.llm_plugin import LLMPlugin
-    llm_plugin = LLMPlugin(pm)
-    pm.register(llm_plugin, name="llm")
-
-    # Register CompactionPlugin before Agent (provides default compaction strategy)
-    from corvidae.compaction import CompactionPlugin
-    compaction_plugin = CompactionPlugin(pm)
-    pm.register(compaction_plugin, name="compaction")
-
-    # Register ThinkingPlugin before Agent (handles <think> block stripping)
-    from corvidae.thinking import ThinkingPlugin
-    thinking_plugin = ThinkingPlugin(pm)
-    pm.register(thinking_plugin, name="thinking")
-
-    # Disabled — ContextCompactPlugin fights with CompactionPlugin over the same
-    # conversation. Re-enable when the two are coordinated or merged.
-    # from corvidae.context_compact import ContextCompactPlugin
-    # context_compact_plugin = ContextCompactPlugin(pm)
-    # pm.register(context_compact_plugin, name="context_compact")
-
-    # Register RuntimeSettingsPlugin before Agent (provides set_settings tool)
-    from corvidae.tools.settings import RuntimeSettingsPlugin
-    immutable_settings = set(agent_defaults.get("immutable_settings", []))
-    runtime_settings_plugin = RuntimeSettingsPlugin(pm, immutable_settings=immutable_settings)
-    pm.register(runtime_settings_plugin, name="runtime_settings")
-
-    # Disabled per operator request — re-enable when ready.
-    # from corvidae.tools.index import WorkspaceIndexerPlugin
-    # local_indexer_plugin = WorkspaceIndexerPlugin(pm)
-    # pm.register(local_indexer_plugin, name="local_indexer")
-
-   # Register ToolCollectionPlugin after all tool-providing plugins (its on_start
-    # uses trylast=True so it fires after all other on_start hooks have run).
-    from corvidae.tool_collection import ToolCollectionPlugin
-    tool_collection_plugin = ToolCollectionPlugin(pm)
-    pm.register(tool_collection_plugin, name="tools")
-
-    # Register DreamPlugin for background memory consolidation
-    from corvidae.tools.dream import DreamPlugin
-    workspace_root = Path(config_path).parent
-    dream_plugin = DreamPlugin(workspace_root=workspace_root)
-    pm.register(dream_plugin, name="dream")
-
-    # Register Agent after tool-providing and transport plugins.
-    # Agent.on_start/on_stop are called explicitly (not via broadcast)
-    # so that on_start runs after all plugins are ready and on_stop runs
-    # before other plugins tear down resources.
-    agent = Agent(pm)
-    pm.register(agent, name="agent")
-
-    # Register IdleMonitorPlugin after Agent (depends on agent)
-    from corvidae.idle import IdleMonitorPlugin
-    idle_monitor_plugin = IdleMonitorPlugin(pm)
-    pm.register(idle_monitor_plugin, name="idle_monitor")
+    # Load all entry-point plugins. These are instantiated with no arguments.
+    pm.load_setuptools_entrypoints("corvidae")
 
     validate_dependencies(pm)
 
+    await pm.ahook.on_init(pm=pm, config=config)
     await pm.ahook.on_start(config=config)
+
+    agent = pm.get_plugin("agent")
+    if agent is None:
+        raise RuntimeError("Agent plugin not registered — check entry points")
     await agent.on_start(config=config)
 
     stop_event = asyncio.Event()
@@ -208,7 +122,7 @@ async def main(config_path: str = "agent.yaml", *, cli_mode: bool = False) -> No
         os._exit(1)
 
 
-async def _run_shutdown(agent: Agent, pm: pluggy.PluginManager) -> None:
+async def _run_shutdown(agent: object, pm: pluggy.PluginManager) -> None:
     """Run agent and plugin shutdown in order. Called under a timeout in main().
 
     On timeout cancellation, pm.ahook.on_stop() may not execute if

--- a/corvidae/mcp_client.py
+++ b/corvidae/mcp_client.py
@@ -26,7 +26,7 @@ import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.tool import Tool
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class _McpServerState:
     mcp_tools: list          # list[mcp.types.Tool]
 
 
-class McpClientPlugin:
+class McpClientPlugin(CorvidaePlugin):
     """Plugin that connects to MCP servers and exposes their tools to Corvidae.
 
     Lifecycle:
@@ -57,18 +57,25 @@ class McpClientPlugin:
     register_tools fires.
     """
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self._servers: list[_McpServerState] = []
         self._cached_tools: list[Tool] = []
         self._exit_stack: AsyncExitStack | None = None
+        self._servers_config: dict = {}
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        self._servers_config = config.get("mcp", {}).get("servers", {})
 
     @hookimpl
     async def on_start(self, config: dict) -> None:
         """Connect to MCP servers and build tool list."""
-        servers_config = config.get("mcp", {}).get("servers", {})
+        servers_config = self._servers_config
         if not servers_config:
             logger.debug("McpClientPlugin: no servers configured")
             return

--- a/corvidae/persistence.py
+++ b/corvidae/persistence.py
@@ -17,7 +17,7 @@ import logging
 import time
 import aiosqlite
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
 logger = logging.getLogger(__name__)
 
@@ -56,19 +56,20 @@ def _parse_message_rows(rows: list[tuple]) -> list[dict]:
     return result
 
 
-class PersistencePlugin:
+class PersistencePlugin(CorvidaePlugin):
     """Plugin that manages SQLite database lifecycle and conversation persistence.
 
     Attributes:
-        pm: Plugin manager instance.
+        pm: Plugin manager instance (set in on_init via CorvidaePlugin).
         db: aiosqlite.Connection, opened in on_start, closed in on_stop.
             Public for test injection (same pattern as former Agent.db).
     """
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self.db: aiosqlite.Connection | None = None
 
     @hookimpl

--- a/corvidae/task.py
+++ b/corvidae/task.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from corvidae.channel import Channel
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.tool import Tool
 
 logger = logging.getLogger(__name__)
@@ -186,15 +186,25 @@ class TaskQueue:
         return "\n".join(parts)
 
 
-class TaskPlugin:
+class TaskPlugin(CorvidaePlugin):
     """Plugin owning the TaskQueue and task_status tool."""
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
         self.task_queue: TaskQueue | None = None
         self._worker_task: asyncio.Task | None = None
+        self._max_workers: int = 4
+        self._completed_buffer: int = 100
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        daemon_config = config.get("daemon", {})
+        self._max_workers = daemon_config.get("max_task_workers", 4)
+        self._completed_buffer = daemon_config.get("completed_task_buffer", 100)
 
     @hookimpl
     def register_tools(self, tool_registry: list) -> None:
@@ -210,10 +220,10 @@ class TaskPlugin:
 
     @hookimpl
     async def on_start(self, config: dict) -> None:
-        daemon_config = config.get("daemon", {})
-        max_workers = daemon_config.get("max_task_workers", 4)
-        completed_buffer = daemon_config.get("completed_task_buffer", 100)
-        self.task_queue = TaskQueue(max_workers=max_workers, completed_buffer=completed_buffer)
+        self.task_queue = TaskQueue(
+            max_workers=self._max_workers,
+            completed_buffer=self._completed_buffer,
+        )
 
         self._worker_task = asyncio.create_task(
             self.task_queue.run_worker(self._on_task_complete)

--- a/corvidae/thinking.py
+++ b/corvidae/thinking.py
@@ -6,10 +6,10 @@ into a standalone plugin that can be unregistered without crashing the system.
 from __future__ import annotations
 
 from corvidae.agent_loop import strip_reasoning_content, strip_thinking
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
 
-class ThinkingPlugin:
+class ThinkingPlugin(CorvidaePlugin):
     """Plugin that handles <think> block and reasoning_content stripping.
 
     Implements two hooks:
@@ -19,10 +19,11 @@ class ThinkingPlugin:
       response text before it is sent to the channel.
     """
 
-    depends_on = {"registry"}
+    depends_on = frozenset({"registry"})
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
 
     @hookimpl
     async def after_persist_assistant(self, channel, message) -> None:

--- a/corvidae/tool_collection.py
+++ b/corvidae/tool_collection.py
@@ -13,24 +13,26 @@ Config:
       max_tool_result_chars: 100000  # migrated to tools.max_result_chars
 """
 import logging
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.tool import Tool, ToolRegistry
 
 logger = logging.getLogger(__name__)
 
 
-class ToolCollectionPlugin:
+class ToolCollectionPlugin(CorvidaePlugin):
     """Plugin that collects and owns the tool registry."""
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm):
-        self.pm = pm
+    def __init__(self, pm=None):
+        if pm is not None:
+            self.pm = pm
         self.registry: ToolRegistry | None = None
         self.max_result_chars: int = 100_000
 
-    @hookimpl(trylast=True)
-    async def on_start(self, config: dict) -> None:
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
         tools_config = config.get("tools", {})
         fallback = config.get("agent", {}).get("max_tool_result_chars")
         if "max_result_chars" in tools_config:
@@ -44,6 +46,8 @@ class ToolCollectionPlugin:
         else:
             self.max_result_chars = 100_000
 
+    @hookimpl(trylast=True)
+    async def on_start(self, config: dict) -> None:
         # Collect tools from all plugins via register_tools hook (sync).
         collected: list = []
         self.pm.hook.register_tools(tool_registry=collected)

--- a/corvidae/tools/__init__.py
+++ b/corvidae/tools/__init__.py
@@ -2,7 +2,7 @@
 
 import aiohttp
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.tool import Tool
 
 from corvidae.tools.shell import shell
@@ -10,11 +10,11 @@ from corvidae.tools.files import read_file, write_file
 from corvidae.tools.web import web_fetch, web_fetch_with_session, web_search
 
 
-class CoreToolsPlugin:
-    depends_on = set()
+class CoreToolsPlugin(CorvidaePlugin):
+    depends_on = frozenset()
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        self.pm = pm  # May be None; on_init will set it via CorvidaePlugin.on_init
         self._session: aiohttp.ClientSession | None = None
         self._shell_timeout: int = 30
         self._web_fetch_timeout: int = 15
@@ -23,13 +23,17 @@ class CoreToolsPlugin:
         self._web_search_max_results: int = 8
 
     @hookimpl
-    async def on_start(self, config: dict) -> None:
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
         tools_config = config.get("tools", {})
         self._shell_timeout = tools_config.get("shell_timeout", 30)
         self._web_fetch_timeout = tools_config.get("web_fetch_timeout", 15)
         self._web_max_response_bytes = tools_config.get("web_max_response_bytes", 50_000)
         self._max_file_read_bytes = tools_config.get("max_file_read_bytes", 1024 * 1024)
         self._web_search_max_results = tools_config.get("web_search_max_results", 8)
+
+    @hookimpl
+    async def on_start(self, config: dict) -> None:
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self._web_fetch_timeout)
         )

--- a/corvidae/tools/dream.py
+++ b/corvidae/tools/dream.py
@@ -29,10 +29,12 @@ from typing import Any
 
 import aiosqlite
 
+from corvidae.hooks import CorvidaePlugin, hookimpl
+
 logger = logging.getLogger(__name__)
 
 
-class DreamPlugin:
+class DreamPlugin(CorvidaePlugin):
     """Periodically reviews recent conversation history and updates MEMORY.md."""
 
     # How many raw rows to load per channel (buffer for non-assistant messages).
@@ -44,22 +46,38 @@ class DreamPlugin:
     # Minimum seconds between dream cycles (configurable).
     DEFAULT_INTERVAL = 300
 
-    def __init__(self, workspace_root: str | Path) -> None:
-        self.workspace_root = Path(workspace_root).resolve()
+    depends_on = frozenset()
+
+    def __init__(self, workspace_root: str | Path | None = None) -> None:
+        if workspace_root is not None:
+            self.workspace_root = Path(workspace_root).resolve()
+        else:
+            self.workspace_root = None
         self.interval_seconds: int = self.DEFAULT_INTERVAL
         self._last_dream_time: float = 0.0
         self._db_path: Path | None = None
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        """Read workspace root from config."""
+        await super().on_init(pm, config)
+        base_dir = config.get("_base_dir")
+        if base_dir is not None:
+            self.workspace_root = Path(base_dir).resolve()
 
     # ------------------------------------------------------------------
     # Lifecycle hooks
     # ------------------------------------------------------------------
 
+    @hookimpl
     async def on_start(self, config: dict) -> None:
         """Read dream config and locate the SQLite DB."""
         dream_cfg = config.get("dream", {})
         self.interval_seconds = dream_cfg.get("interval_seconds", self.DEFAULT_INTERVAL)
-        self._db_path = self._locate_db()
+        if self.workspace_root is not None:
+            self._db_path = self._locate_db()
 
+    @hookimpl
     async def on_idle(self) -> None:
         """Trigger a dream cycle if enough time has elapsed and DB is ready."""
         now = time.time()

--- a/corvidae/tools/settings.py
+++ b/corvidae/tools/settings.py
@@ -8,25 +8,38 @@ sensitive keys. "system_prompt" is always blocked regardless of operator config.
 
 import logging
 
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.tool import Tool, tool_to_schema
 
 logger = logging.getLogger(__name__)
 
 
-class RuntimeSettingsPlugin:
+class RuntimeSettingsPlugin(CorvidaePlugin):
     """Plugin that registers the set_settings tool.
 
-    Args:
-        immutable_settings: Set of key names that the agent must not be
-            allowed to change. "system_prompt" is always added to this set.
+    The default blocklist always includes "system_prompt". Additional
+    immutable settings are read from config in on_init.
+
+    Legacy usage: RuntimeSettingsPlugin(pm, immutable_settings=...) is still
+    accepted for backward compatibility with existing tests.
     """
 
-    depends_on = set()
+    depends_on = frozenset()
 
-    def __init__(self, pm, *, immutable_settings: set) -> None:
-        self.pm = pm
-        self.blocklist: set = {"system_prompt"} | set(immutable_settings)
+    def __init__(self, pm=None, *, immutable_settings: set | None = None) -> None:
+        # Backward-compatible: accept optional pm positional arg and
+        # immutable_settings keyword arg so existing test code still works.
+        if pm is not None:
+            self.pm = pm
+        self.blocklist: set = {"system_prompt"}
+        if immutable_settings is not None:
+            self.blocklist |= set(immutable_settings)
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        immutable = config.get("agent", {}).get("immutable_settings", [])
+        self.blocklist |= set(immutable)
 
     @hookimpl
     def register_tools(self, tool_registry: list) -> None:

--- a/corvidae/tools/subagent.py
+++ b/corvidae/tools/subagent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from corvidae.agent_loop import run_agent_loop, strip_thinking
-from corvidae.hooks import get_dependency, hookimpl
+from corvidae.hooks import CorvidaePlugin, get_dependency, hookimpl
 from corvidae.task import Task
 from corvidae.tool import ToolContext
 
@@ -18,7 +18,7 @@ SUBAGENT_SYSTEM_PROMPT = (
 )
 
 
-class SubagentPlugin:
+class SubagentPlugin(CorvidaePlugin):
     """Plugin that registers the subagent tool.
 
     Launches background agents via run_agent_loop. All subagents share the
@@ -31,10 +31,11 @@ class SubagentPlugin:
     max_result_chars at tool-call time.
     """
 
-    depends_on = {"llm", "tools"}
+    depends_on = frozenset({"llm", "tools"})
 
-    def __init__(self, pm) -> None:
-        self.pm = pm
+    def __init__(self, pm=None) -> None:
+        if pm is not None:
+            self.pm = pm
 
     @hookimpl
     async def on_start(self, config: dict) -> None:

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -1,31 +1,36 @@
 # Corvidae Plugin Guide
 
-Corvidae plugins extend the agent daemon using [apluggy](https://pypi.org/project/apluggy/) (async pluggy). A plugin is a class with `@hookimpl`-decorated methods corresponding to the hooks it wants to handle.
+Corvidae plugins extend the agent daemon using [apluggy](https://pypi.org/project/apluggy/) (async pluggy). A plugin subclasses `CorvidaePlugin` and decorates methods with `@hookimpl` for each hook it handles.
 
 ```python
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
-class GreetPlugin:
-    def __init__(self, pm) -> None:
-        self.pm = pm
-
+class GreetPlugin(CorvidaePlugin):
     @hookimpl
     async def on_message(self, channel, sender: str, text: str) -> None:
         if text.strip().lower() == "hello":
             await self.pm.ahook.send_message(channel=channel, text=f"Hello, {sender}!")
 ```
 
+`CorvidaePlugin.on_init` stores `pm` and `config` as instance attributes. Subclasses that need extra initialization override `on_init` and call `super().on_init(pm, config)` first.
+
 ## Plugin anatomy
 
-A plugin is a plain Python class. It only needs to implement the hooks it cares about — all hooks are optional. The `@hookimpl` decorator marks each implementation.
+A plugin subclasses `CorvidaePlugin` from `corvidae.hooks`. It only needs to implement the hooks it cares about — all hooks are optional. The `@hookimpl` decorator marks each implementation. Plugins use no-argument constructors; `pm` and `config` are received via the `on_init` hook.
 
 ```python
-from corvidae.hooks import hookimpl
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
-class MyPlugin:
+class MyPlugin(CorvidaePlugin):
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        self.setting = config.get("my_plugin", {}).get("setting", "default")
+
     @hookimpl
     async def on_start(self, config: dict) -> None:
-        self.setting = config.get("my_plugin", {}).get("setting", "default")
+        # open runtime resources (connections, file handles, asyncio tasks)
+        pass
 
     @hookimpl
     async def on_stop(self) -> None:
@@ -35,30 +40,18 @@ class MyPlugin:
 
 ## Registering a plugin
 
-### Built-in (in main.py)
-
-Add a `pm.register()` call before `validate_dependencies()`:
-
-```python
-# corvidae/main.py
-my_plugin = MyPlugin(pm)
-pm.register(my_plugin, name="my_plugin")
-
-validate_dependencies(pm)
-```
-
-Registration order matters: tool-providing plugins must be registered before `tools` (ToolCollectionPlugin) so their tools are collected when `ToolCollectionPlugin.on_start` runs. Transport plugins must be registered before `agent`.
-
-### External (setuptools entry points)
-
-External plugins are loaded automatically via `pm.load_setuptools_entrypoints("corvidae")`. Declare them in `pyproject.toml`:
+Plugins are loaded via setuptools entry points. Declare them in `pyproject.toml`:
 
 ```toml
 [project.entry-points.corvidae]
 my_plugin = "my_package:MyPlugin"
 ```
 
-The entry point value must be importable and callable by pluggy's loader (a class or factory function). Internal plugins all accept `pm` as their first constructor argument; external plugins loaded via entry points are instantiated by pluggy without arguments, so they must provide a no-argument constructor or use a factory function.
+`main.py` calls `pm.load_setuptools_entrypoints("corvidae")`, which instantiates each entry point class with no arguments and registers it. `validate_dependencies(pm)` runs next, then `pm.ahook.on_init(pm=pm, config=config)` broadcasts to all registered plugins.
+
+All plugin classes must be instantiable with no arguments. `pm` and `config` are delivered via `on_init`.
+
+**ChannelRegistry** is the exception: it is not an entry-point plugin. It is a plain class with no `@hookimpl` decorators, constructed explicitly in `main.py` and populated from config before the entry point plugins are loaded.
 
 ## Available hooks
 
@@ -66,10 +59,13 @@ The entry point value must be importable and callable by pluggy's loader (a clas
 
 | Hook | Type | When |
 |------|------|------|
-| `on_start(config: dict)` | async broadcast | Once at startup, after config is loaded |
+| `on_init(pm, config: dict)` | async broadcast | After all plugins are registered, before `on_start`. Use to store `pm`, read config values, and resolve references to other plugins. Do not create runtime resources here. |
+| `on_start(config: dict)` | async broadcast | Once at startup, after `on_init`. Use to open runtime resources: DB connections, network clients, file handles, asyncio tasks. |
 | `on_stop()` | async broadcast | On SIGINT/SIGTERM, before process exits |
 
 `config` is the full parsed `agent.yaml` dict. The key `_base_dir` (a `Path`) is injected by `main.py` pointing to the config file's directory.
+
+`CorvidaePlugin.on_init` stores `pm` and `config` as instance attributes. Subclasses that override `on_init` must call `await super().on_init(pm, config)` to preserve this behavior.
 
 ### Messaging
 
@@ -197,11 +193,8 @@ class MyPlugin:
 Declare `depends_on` as a class attribute (a set of plugin names). `validate_dependencies()` raises `RuntimeError` at startup if any declared dependency is not registered, or if the dependency graph contains a cycle. The error message includes the full cycle path, e.g. `Dependency cycle detected: a -> b -> a`.
 
 ```python
-class MyPlugin:
+class MyPlugin(CorvidaePlugin):
     depends_on = {"agent", "task"}
-
-    def __init__(self, pm) -> None:
-        self.pm = pm
 ```
 
 To get a typed reference to a dependency:
@@ -222,8 +215,9 @@ registry = tools_plugin.get_registry()
 
 ```python
 from corvidae.context import MessageType
+from corvidae.hooks import CorvidaePlugin, hookimpl
 
-class MemoryPlugin:
+class MemoryPlugin(CorvidaePlugin):
     @hookimpl
     async def before_agent_turn(self, channel) -> None:
         notes = await self.fetch_relevant_notes(channel.id)
@@ -271,35 +265,37 @@ irc:
 
 ## Registration order
 
-The current registration sequence in `main.py`:
+Plugins are loaded via `pm.load_setuptools_entrypoints("corvidae")`. The entry point loading order is non-deterministic — it is not guaranteed to match any specific sequence. The following plugins are registered:
 
 ```
-registry          (ChannelRegistry)
-persistence       (PersistencePlugin)
-jsonl_log         (JsonlLogPlugin)
-core_tools        (CoreToolsPlugin)
-cli               (CLIPlugin)
-irc               (IRCPlugin)
-task              (TaskPlugin)
-subagent          (SubagentPlugin)
-mcp               (McpClientPlugin)
-llm               (LLMPlugin)
-compaction        (CompactionPlugin)
-thinking          (ThinkingPlugin)
-runtime_settings  (RuntimeSettingsPlugin)
-tools             (ToolCollectionPlugin)
-dream             (DreamPlugin)
-agent             (Agent)
-idle_monitor      (IdleMonitorPlugin)
+registry          (ChannelRegistry)     — explicit, before entry points load
+persistence       (PersistencePlugin)   — entry point
+jsonl_log         (JsonlLogPlugin)      — entry point
+core_tools        (CoreToolsPlugin)     — entry point
+cli               (CLIPlugin)           — entry point
+irc               (IRCPlugin)           — entry point
+task              (TaskPlugin)          — entry point
+subagent          (SubagentPlugin)      — entry point
+mcp               (McpClientPlugin)     — entry point
+llm               (LLMPlugin)           — entry point
+compaction        (CompactionPlugin)    — entry point
+thinking          (ThinkingPlugin)      — entry point
+runtime_settings  (RuntimeSettingsPlugin) — entry point
+tools             (ToolCollectionPlugin) — entry point
+dream             (DreamPlugin)         — entry point
+agent             (Agent)               — entry point
+idle_monitor      (IdleMonitorPlugin)   — entry point
 ```
 
-Tool-providing plugins and transport plugins register before `tools` (ToolCollectionPlugin). `ToolCollectionPlugin.on_start` uses `@hookimpl(trylast=True)` so it fires after all other `on_start` hooks; at that point it calls `register_tools` to collect tools from every registered plugin. `Agent._start_plugin` then calls `get_dependency(pm, "tools", ToolCollectionPlugin)` to retrieve the fully populated registry.
+`ChannelRegistry` is constructed and registered explicitly before entry points load. Its `agent_defaults` attribute and channel config are populated from config before the `on_init` broadcast runs.
 
-**Startup order:** `main.py` calls `pm.ahook.on_start(config=config)` first, which runs all plugins' `on_start` hooks. `ToolCollectionPlugin.on_start` runs last (trylast) to ensure all tool providers have initialized. Then `main.py` calls `agent.on_start(config=config)` explicitly. `Agent.on_start` does not have `@hookimpl` — it is called only by `main.py`.
+**Tool collection:** `ToolCollectionPlugin.on_start` uses `@hookimpl(trylast=True)` so it fires after all other `on_start` hooks, then calls `register_tools` to collect tools from every registered plugin. The non-deterministic loading order does not affect tool collection because `trylast=True` ensures `ToolCollectionPlugin.on_start` always runs last in the broadcast.
+
+**Startup order:** `main.py` broadcasts `on_init`, then `on_start`. `ToolCollectionPlugin.on_start` runs last (trylast) to collect tools. `main.py` then calls `agent.on_start(config=config)` explicitly after the broadcast completes. `Agent.on_start` does not have `@hookimpl` — it is called only by `main.py`. Adding `@hookimpl` to `Agent.on_start` would cause double initialization.
 
 **Shutdown order:** `main.py` calls `agent.on_stop()` first (drains queues), then `pm.ahook.on_stop()` to tear down all other plugins.
 
-`idle_monitor` registers after `agent` because it depends on `"agent"`. Its `on_start` uses `@hookimpl(trylast=True)` to run late in the broadcast. Because `Agent.on_start` is called after the broadcast completes, `idle_monitor` is always initialized before `Agent` starts.
+`idle_monitor` depends on `"agent"`. Its `on_start` uses `@hookimpl(trylast=True)` to run late in the broadcast. Because `Agent.on_start` is called after the broadcast completes, `idle_monitor` is always initialized before `Agent` starts.
 
 ## Hook exception safety
 
@@ -337,7 +333,7 @@ The legacy key `agent.max_tool_result_chars` is still accepted but deprecated; a
 
 ### CoreToolsPlugin tools
 
-Registered by `CoreToolsPlugin` (registered as `core_tools` in `main.py`).
+Registered by `CoreToolsPlugin` (entry point name: `core_tools`).
 
 | Tool | Parameters | What it does |
 |------|------------|--------------|
@@ -361,7 +357,7 @@ tools:
 
 ### SubagentPlugin tools
 
-Registered by `SubagentPlugin` (registered as `subagent` in `main.py`).
+Registered by `SubagentPlugin` (entry point name: `subagent`).
 
 | Tool | Parameters | What it does |
 |------|------------|--------------|
@@ -371,7 +367,7 @@ Registered by `SubagentPlugin` (registered as `subagent` in `main.py`).
 
 ### RuntimeSettingsPlugin tools
 
-Registered by `RuntimeSettingsPlugin` (registered as `"runtime_settings"` in `main.py`).
+Registered by `RuntimeSettingsPlugin` (entry point name: `runtime_settings`).
 
 | Tool | Parameters | What it does |
 |------|------------|--------------|
@@ -379,15 +375,12 @@ Registered by `RuntimeSettingsPlugin` (registered as `"runtime_settings"` in `ma
 
 ## Bundled plugins
 
-These plugins are registered by `main.py` and are part of the default
-daemon. They can be omitted if the application does not need their
-functionality; each degrades gracefully when absent.
+These plugins ship with Corvidae and are registered via entry points as part of the default daemon. They can be omitted if the application does not need their functionality; each degrades gracefully when absent.
 
 ### McpClientPlugin (`corvidae/mcp_client.py`)
 
 Connects to external [MCP](https://modelcontextprotocol.io/) servers and
-exposes their tools to the agent loop. Registered as `"mcp"` before
-`agent`.
+exposes their tools to the agent loop. Entry point name: `"mcp"`.
 
 Implements three hooks:
 
@@ -428,7 +421,7 @@ if the `mcp:` config key is absent — the plugin no-ops.
 ### ThinkingPlugin (`corvidae/thinking.py`)
 
 Strips `<think>...</think>` blocks and `reasoning_content` from LLM
-output. Registered as `"thinking"` before `agent`.
+output. Entry point name: `"thinking"`.
 
 Implements two hooks:
 
@@ -447,7 +440,7 @@ regardless of the `keep_thinking_in_history` config value.
 ### CompactionPlugin (`corvidae/compaction.py`)
 
 Compacts conversation history when it approaches the channel's
-`max_context_tokens` limit. Registered as `"compaction"` before `agent`.
+`max_context_tokens` limit. Entry point name: `"compaction"`.
 
 Implements one hook:
 
@@ -476,7 +469,7 @@ receive an error from the API when the context limit is exceeded.
 ### PersistencePlugin (`corvidae/persistence.py`)
 
 Opens the SQLite database, runs schema migrations, and sets the journal mode.
-Registered as `"persistence"` before `agent`. Implements `on_start`,
+Entry point name: `"persistence"`. Implements `on_start`,
 `on_stop`, `load_conversation`, `on_conversation_event`, and `on_compaction`.
 
 **Config:**
@@ -494,8 +487,7 @@ history is not persisted across restarts.
 
 Writes an append-only JSONL log of conversation events alongside the SQLite
 store. Each `on_conversation_event` and `on_compaction` call produces one
-JSON line in a per-channel file. Registered as `"jsonl_log"` after
-`persistence`.
+JSON line in a per-channel file. Entry point name: `"jsonl_log"`.
 
 Implements three hooks:
 
@@ -520,8 +512,7 @@ still persisted in SQLite by `PersistencePlugin`.
 
 ### LLMPlugin (`corvidae/llm_plugin.py`)
 
-Owns the `LLMClient` instance lifecycle. Registered as `"llm"` before
-`compaction` and `agent`. Other plugins retrieve clients via
+Owns the `LLMClient` instance lifecycle. Entry point name: `"llm"`. Other plugins retrieve clients via
 `get_dependency(pm, "llm", LLMPlugin)`.
 
 Implements two hooks:
@@ -557,7 +548,7 @@ clients and will raise `RuntimeError` during startup.
 ### TaskPlugin (`corvidae/task.py`)
 
 Owns the `TaskQueue` and delivers task results via the `on_notify` hook.
-Registered as `"task"` before `agent`.
+Entry point name: `"task"`.
 
 **Config:**
 ```yaml
@@ -573,8 +564,7 @@ without a `TaskQueue`.
 ### RuntimeSettingsPlugin (`corvidae/tools/settings.py`)
 
 Registers the `set_settings` tool, which lets the agent update per-channel
-LLM inference parameters and framework settings at runtime. Registered as
-`"runtime_settings"` before `tools`.
+LLM inference parameters and framework settings at runtime. Entry point name: `"runtime_settings"`.
 
 Implements one hook:
 
@@ -600,7 +590,7 @@ settings can only be configured statically in `agent.yaml`.
 ### ToolCollectionPlugin (`corvidae/tool_collection.py`)
 
 Collects tools from all registered plugins and owns the `ToolRegistry`.
-Registered as `"tools"` after all tool-providing plugins.
+Entry point name: `"tools"`.
 
 Implements one hook:
 
@@ -610,7 +600,7 @@ Implements one hook:
   `agent.max_tool_result_chars`) to configure the per-call result truncation
   limit.
 
-`Agent._start_plugin` retrieves the registry via
+`Agent` retrieves the registry via
 `get_dependency(pm, "tools", ToolCollectionPlugin)`. The `trylast=True`
 marker guarantees all tool providers have fully initialized before collection
 runs.
@@ -631,13 +621,11 @@ tools_dict, schemas = tools_plugin.get_tools()
 ### DreamPlugin (`corvidae/tools/dream.py`)
 
 Periodically reviews recent conversation history and appends extracted facts
-to `MEMORY.md`. Registered as `"dream"` before `agent`.
+to `MEMORY.md`. Entry point name: `"dream"`.
 
-Implements two hooks (not decorated with `@hookimpl` — registered as a
-plain plugin object):
+Implements two hooks:
 
-- `on_start` — reads `dream.interval_seconds` (default 300) and locates
-  `sessions.db` within the workspace tree.
+- `on_start` — locates `sessions.db` within the workspace tree.
 - `on_idle` — runs a dream cycle if `interval_seconds` have elapsed since
   the last cycle. Queries the last 40 rows from `message_log`, filters for
   assistant messages, strips `<think>` blocks, and appends new sentences to
@@ -657,15 +645,13 @@ dream:
 ### IdleMonitorPlugin (`corvidae/idle.py`)
 
 Fires the `on_idle` broadcast hook when all queues are quiescent.
-Registered as `"idle_monitor"` after `agent`.
+Entry point name: `"idle_monitor"`.
 
-Depends on `"agent"`. Its `on_start` uses `@hookimpl(trylast=True)`
-to run late in the broadcast. `Agent.on_start` is called by
-`main.py` after the broadcast completes, so the idle monitor is always
-initialized before the agent starts. It
-retrieves `Agent.queues` (a `dict[str, SerialQueue]`) by reference,
-so queues created after `IdleMonitorPlugin.on_start` are included
-automatically.
+Currently a stub — implements `on_idle` as a no-op. The idle
+detection logic itself lives in `Agent._maybe_fire_idle`, which
+checks queue quiescence and fires the `on_idle` broadcast.
+Plugins that implement `on_idle` (such as `DreamPlugin`) receive
+those calls.
 
 **Idle condition:** all `SerialQueue` instances have `is_empty=True`,
 `TaskQueue.is_idle` is `True` (skipped if `TaskPlugin` is not
@@ -678,4 +664,4 @@ daemon:
   idle_cooldown_seconds: 30   # minimum seconds between on_idle firings (default 30)
 ```
 
-**Without this plugin:** the `on_idle` hook is never fired.
+**Without this plugin:** the `on_idle` hook is never fired. Plugins that implement `on_idle` (such as `DreamPlugin`) will not receive calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,35 @@ dev = [
 [project.scripts]
 corvidae = "corvidae.main:cli"
 
+[project.entry-points.corvidae]
+persistence = "corvidae.persistence:PersistencePlugin"
+jsonl_log = "corvidae.jsonl_log:JsonlLogPlugin"
+core_tools = "corvidae.tools:CoreToolsPlugin"
+cli = "corvidae.channels.cli:CLIPlugin"
+irc = "corvidae.channels.irc:IRCPlugin"
+task = "corvidae.task:TaskPlugin"
+subagent = "corvidae.tools.subagent:SubagentPlugin"
+mcp = "corvidae.mcp_client:McpClientPlugin"
+llm = "corvidae.llm_plugin:LLMPlugin"
+compaction = "corvidae.compaction:CompactionPlugin"
+thinking = "corvidae.thinking:ThinkingPlugin"
+runtime_settings = "corvidae.tools.settings:RuntimeSettingsPlugin"
+tools = "corvidae.tool_collection:ToolCollectionPlugin"
+dream = "corvidae.tools.dream:DreamPlugin"
+agent = "corvidae.agent:Agent"
+idle_monitor = "corvidae.idle:IdleMonitorPlugin"
+
 [tool.setuptools.packages.find]
 include = ["corvidae*"]
 
 [build-system]
 requires = ["setuptools>=75"]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+    "pytest-timeout>=2.4.0",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -45,7 +45,8 @@ async def build_plugin_and_channel(
     await init_db(db)
 
     pm = create_plugin_manager()
-    registry = ChannelRegistry(agent_defaults)
+    registry = ChannelRegistry()
+    registry.agent_defaults = agent_defaults
     pm.register(registry, name="registry")
 
     if mock_send_message:
@@ -53,20 +54,23 @@ async def build_plugin_and_channel(
     if mock_on_agent_response:
         pm.ahook.on_agent_response = AsyncMock()
 
-    task_plugin = TaskPlugin(pm)
+    task_plugin = TaskPlugin()
     pm.register(task_plugin, name="task")
+    await task_plugin.on_init(pm=pm, config={})
     await task_plugin.on_start(config={})
 
-    persistence = PersistencePlugin(pm)
+    persistence = PersistencePlugin()
     persistence.db = db
     persistence._registry = registry
     pm.register(persistence, name="persistence")
 
-    thinking_plugin = ThinkingPlugin(pm)
+    thinking_plugin = ThinkingPlugin()
     pm.register(thinking_plugin, name="thinking")
+    await thinking_plugin.on_init(pm=pm, config={})
 
-    plugin = Agent(pm)
+    plugin = Agent()
     pm.register(plugin, name="agent")
+    plugin.pm = pm
     plugin._registry = registry
 
     channel = registry.get_or_create(

--- a/tests/test_irc_plugin.py
+++ b/tests/test_irc_plugin.py
@@ -122,6 +122,8 @@ class TestOnStart:
         plugin = IRCPlugin(pm)
         pm.register(plugin, name="irc")
 
+        # on_init now reads channel config; must be called before on_start
+        await plugin.on_init(pm=pm, config=IRC_CONFIG)
         # The real connect_with_retry will call the mocked connect (which blocks forever)
         await plugin.on_start(config=IRC_CONFIG)
 

--- a/tests/test_jsonl_log.py
+++ b/tests/test_jsonl_log.py
@@ -37,6 +37,7 @@ class TestJsonlPluginNoOp:
 
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -90,6 +91,7 @@ class TestJsonlPluginCreatesDirectory:
 
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         assert log_dir.exists()
@@ -114,6 +116,7 @@ class TestOnConversationEvent:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -145,6 +148,7 @@ class TestOnConversationEvent:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -167,6 +171,7 @@ class TestOnConversationEvent:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -196,6 +201,7 @@ class TestOnConversationEvent:
 
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {}}  # no jsonl_log_dir
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -217,6 +223,7 @@ class TestOnConversationEvent:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -253,6 +260,7 @@ class TestOnCompaction:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -283,6 +291,7 @@ class TestOnCompaction:
 
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -310,6 +319,7 @@ class TestJsonlPluginSanitizesChannelId:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -330,6 +340,7 @@ class TestJsonlPluginSanitizesChannelId:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("irc:#general/topic")
@@ -359,6 +370,7 @@ class TestJsonlPluginStop:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -389,6 +401,7 @@ class TestJsonlPluginValidJson:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")
@@ -420,6 +433,7 @@ class TestJsonlPluginValidJson:
         log_dir = tmp_path / "logs"
         plugin = JsonlLogPlugin(None)
         config = {"daemon": {"jsonl_log_dir": str(log_dir)}}
+        await plugin.on_init(pm=None, config=config)
         await plugin.on_start(config=config)
 
         channel = _make_channel("cli:default")

--- a/tests/test_llm_plugin.py
+++ b/tests/test_llm_plugin.py
@@ -167,20 +167,21 @@ async def test_llm_plugin_on_start_creates_and_starts_main_client():
     """on_start must create main_client and call client.start()."""
     from corvidae.llm_plugin import LLMPlugin
 
-    plugin = LLMPlugin(pm=None)
+    plugin = LLMPlugin()
+    config = {
+        "llm": {
+            "main": {
+                "base_url": "http://localhost:8080",
+                "model": "test-model",
+            }
+        }
+    }
+    await plugin.on_init(pm=MagicMock(), config=config)
 
     mock_client = MagicMock()
     mock_client.start = AsyncMock()
 
     with patch.object(LLMPlugin, "_create_client", return_value=mock_client) as mock_create:
-        config = {
-            "llm": {
-                "main": {
-                    "base_url": "http://localhost:8080",
-                    "model": "test-model",
-                }
-            }
-        }
         await plugin.on_start(config=config)
 
     mock_create.assert_called_once_with(config["llm"]["main"])
@@ -202,13 +203,15 @@ async def test_llm_plugin_on_start_creates_background_client_when_configured():
 
     clients = [main_mock, bg_mock]
 
-    with patch.object(LLMPlugin, "_create_client", side_effect=clients):
-        config = {
-            "llm": {
-                "main": {"base_url": "http://localhost:8080", "model": "main-model"},
-                "background": {"base_url": "http://localhost:9090", "model": "bg-model"},
-            }
+    config = {
+        "llm": {
+            "main": {"base_url": "http://localhost:8080", "model": "main-model"},
+            "background": {"base_url": "http://localhost:9090", "model": "bg-model"},
         }
+    }
+    await plugin.on_init(pm=None, config=config)
+
+    with patch.object(LLMPlugin, "_create_client", side_effect=clients):
         await plugin.on_start(config=config)
 
     main_mock.start.assert_awaited_once()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -197,8 +197,13 @@ def _make_minimal_config(tmp_path, extra=None):
 
 def _make_mock_pm():
     mock_pm = MagicMock()
+    mock_pm.ahook.on_init = AsyncMock(return_value=[])
     mock_pm.ahook.on_start = AsyncMock(return_value=[])
     mock_pm.ahook.on_stop = AsyncMock(return_value=[])
+    mock_agent = MagicMock()
+    mock_agent.on_start = AsyncMock()
+    mock_agent.on_stop = AsyncMock()
+    mock_pm.get_plugin.return_value = mock_agent
     return mock_pm
 
 
@@ -218,10 +223,8 @@ class TestMainLoggingConfiguration:
         import signal
 
         with patch("corvidae.main.configure_logging") as mock_configure, \
-             patch("corvidae.main.create_plugin_manager") as mock_pm_factory, \
-             patch("corvidae.main.Agent") as mock_agent_cls:
+             patch("corvidae.main.create_plugin_manager") as mock_pm_factory:
             mock_pm_factory.return_value = _make_mock_pm()
-            mock_agent_cls.return_value = _make_mock_agent()
 
             async def run():
                 asyncio.get_running_loop().call_later(
@@ -305,10 +308,8 @@ class TestMainLoggingConfiguration:
 
         with caplog.at_level(logging.INFO, logger="corvidae.main"), \
              patch("corvidae.main.configure_logging"), \
-             patch("corvidae.main.create_plugin_manager") as mock_pm_factory, \
-             patch("corvidae.main.Agent") as mock_agent_cls:
+             patch("corvidae.main.create_plugin_manager") as mock_pm_factory:
             mock_pm_factory.return_value = _make_mock_pm()
-            mock_agent_cls.return_value = _make_mock_agent()
 
             async def run():
                 asyncio.get_running_loop().call_later(
@@ -334,10 +335,8 @@ class TestMainLoggingConfiguration:
 
         with caplog.at_level(logging.INFO, logger="corvidae.main"), \
              patch("corvidae.main.configure_logging"), \
-             patch("corvidae.main.create_plugin_manager") as mock_pm_factory, \
-             patch("corvidae.main.Agent") as mock_agent_cls:
+             patch("corvidae.main.create_plugin_manager") as mock_pm_factory:
             mock_pm_factory.return_value = _make_mock_pm()
-            mock_agent_cls.return_value = _make_mock_agent()
 
             async def run():
                 asyncio.get_running_loop().call_later(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,21 +51,8 @@ class TestMainLoadsConfigAndCreatesPM:
             config_path = f.name
 
         try:
-            with patch("corvidae.main.create_plugin_manager") as mock_create, \
-                 patch("corvidae.main.Agent") as mock_agent_cls:
-                # Return a minimal object that satisfies pm.ahook.on_start / on_stop
-                mock_pm = MagicMock()
-                mock_pm.ahook.on_start = AsyncMock(return_value=[])
-                mock_pm.ahook.on_stop = AsyncMock(return_value=[])
-                mock_create.return_value = mock_pm
-                # Agent instance returned by the constructor must support
-                # the explicit on_start / on_stop calls that main() makes after
-                # the broadcast.
-                mock_agent = MagicMock()
-                mock_agent.on_start = AsyncMock()
-                mock_agent.on_stop = AsyncMock()
-                mock_agent_cls.return_value = mock_agent
-
+            mock_pm, mock_agent = _make_mock_pm_and_agent()
+            with patch("corvidae.main.create_plugin_manager", return_value=mock_pm) as mock_create:
                 _schedule_sigint()
                 await main(config_path)
 
@@ -96,34 +83,36 @@ class TestAgentLifecycleOrdering:
         call_order: list[str] = []
 
         try:
-            with patch("corvidae.main.create_plugin_manager") as mock_create, \
-                 patch("corvidae.main.Agent") as mock_agent_cls:
-                mock_pm = MagicMock()
+            mock_pm = MagicMock()
+            mock_agent = MagicMock()
 
-                async def broadcast_on_start(**kwargs):
-                    call_order.append("broadcast_on_start")
-                    return []
+            async def broadcast_on_init(**kwargs):
+                call_order.append("broadcast_on_init")
+                return []
 
-                async def broadcast_on_stop(**kwargs):
-                    call_order.append("broadcast_on_stop")
-                    return []
+            async def broadcast_on_start(**kwargs):
+                call_order.append("broadcast_on_start")
+                return []
 
-                mock_pm.ahook.on_start = AsyncMock(side_effect=broadcast_on_start)
-                mock_pm.ahook.on_stop = AsyncMock(side_effect=broadcast_on_stop)
-                mock_create.return_value = mock_pm
+            async def broadcast_on_stop(**kwargs):
+                call_order.append("broadcast_on_stop")
+                return []
 
-                mock_agent = MagicMock()
+            mock_pm.ahook.on_init = AsyncMock(side_effect=broadcast_on_init)
+            mock_pm.ahook.on_start = AsyncMock(side_effect=broadcast_on_start)
+            mock_pm.ahook.on_stop = AsyncMock(side_effect=broadcast_on_stop)
+            mock_pm.get_plugin.return_value = mock_agent
 
-                async def agent_on_start(**kwargs):
-                    call_order.append("agent_on_start")
+            async def agent_on_start(**kwargs):
+                call_order.append("agent_on_start")
 
-                async def agent_on_stop(**kwargs):
-                    call_order.append("agent_on_stop")
+            async def agent_on_stop(**kwargs):
+                call_order.append("agent_on_stop")
 
-                mock_agent.on_start = AsyncMock(side_effect=agent_on_start)
-                mock_agent.on_stop = AsyncMock(side_effect=agent_on_stop)
-                mock_agent_cls.return_value = mock_agent
+            mock_agent.on_start = AsyncMock(side_effect=agent_on_start)
+            mock_agent.on_stop = AsyncMock(side_effect=agent_on_stop)
 
+            with patch("corvidae.main.create_plugin_manager", return_value=mock_pm):
                 _schedule_sigint()
                 await main(config_path)
 
@@ -178,9 +167,23 @@ class TestMainCallsOnStartAndOnStop:
             async def on_stop(self):
                 await on_stop_mock()
 
+        class _MockAgent:
+            async def on_start(self, config):
+                pass
+
+            async def on_stop(self):
+                pass
+
+        mock_agent = _MockAgent()
+
         def patched_create_plugin_manager():
             pm = create_plugin_manager()
             pm.register(MockPlugin())
+            # Suppress real entry-point loading and register a mock agent so
+            # main() can find pm.get_plugin("agent") without loading the full
+            # plugin stack (which requires mocking LLM, DB, aiohttp, etc.).
+            pm.load_setuptools_entrypoints = lambda *a, **kw: None
+            pm.register(mock_agent, name="agent")
             return pm
 
         with tempfile.NamedTemporaryFile(
@@ -190,25 +193,12 @@ class TestMainCallsOnStartAndOnStop:
             config_path = f.name
 
         try:
-            mock_client = MagicMock()
-            mock_client.start = AsyncMock()
-            mock_client.stop = AsyncMock()
             with patch(
                 "corvidae.main.create_plugin_manager",
                 side_effect=patched_create_plugin_manager,
             ), patch(
-                "corvidae.llm_plugin.LLMClient",
-                return_value=mock_client,
-            ), patch(
-                "corvidae.persistence.aiosqlite.connect",
-                new_callable=AsyncMock,
-            ) as mock_connect, patch(
-                "corvidae.persistence.init_db",
-                new_callable=AsyncMock,
+                "corvidae.main.validate_dependencies",
             ):
-                mock_db = MagicMock()
-                mock_db.close = AsyncMock()
-                mock_connect.return_value = mock_db
                 _schedule_sigint()
                 await main(config_path)
 
@@ -235,10 +225,24 @@ class TestRegistryPopulatedBeforeOnStart:
 
         inspector = InspectorPlugin()
 
+        class _MockAgent:
+            async def on_start(self, config):
+                pass
+
+            async def on_stop(self):
+                pass
+
+        mock_agent = _MockAgent()
+
         def patched_create_plugin_manager():
             nonlocal pm
             pm = create_plugin_manager()
             pm.register(inspector)
+            # Suppress real entry-point loading and register a mock agent so
+            # main() can find pm.get_plugin("agent") without loading the full
+            # plugin stack.
+            pm.load_setuptools_entrypoints = lambda *a, **kw: None
+            pm.register(mock_agent, name="agent")
             return pm
 
         pm = None
@@ -264,25 +268,12 @@ class TestRegistryPopulatedBeforeOnStart:
             config_path = f.name
 
         try:
-            mock_client = MagicMock()
-            mock_client.start = AsyncMock()
-            mock_client.stop = AsyncMock()
             with patch(
                 "corvidae.main.create_plugin_manager",
                 side_effect=patched_create_plugin_manager,
             ), patch(
-                "corvidae.llm_plugin.LLMClient",
-                return_value=mock_client,
-            ), patch(
-                "corvidae.persistence.aiosqlite.connect",
-                new_callable=AsyncMock,
-            ) as mock_connect, patch(
-                "corvidae.persistence.init_db",
-                new_callable=AsyncMock,
+                "corvidae.main.validate_dependencies",
             ):
-                mock_db = MagicMock()
-                mock_db.close = AsyncMock()
-                mock_connect.return_value = mock_db
                 _schedule_sigint()
                 await main(config_path)
         finally:
@@ -311,12 +302,14 @@ class TestMainMissingConfig:
 def _make_mock_pm_and_agent():
     """Return a (mock_pm, mock_agent) pair suitable for main() patches."""
     mock_pm = MagicMock()
+    mock_pm.ahook.on_init = AsyncMock(return_value=[])
     mock_pm.ahook.on_start = AsyncMock(return_value=[])
     mock_pm.ahook.on_stop = AsyncMock(return_value=[])
 
     mock_agent = MagicMock()
     mock_agent.on_start = AsyncMock()
     mock_agent.on_stop = AsyncMock()
+    mock_pm.get_plugin.return_value = mock_agent
     return mock_pm, mock_agent
 
 
@@ -355,7 +348,6 @@ class TestDoubleSignalForceExit:
 
             with (
                 patch("corvidae.main.create_plugin_manager", return_value=mock_pm),
-                patch("corvidae.main.Agent", return_value=mock_agent),
                 patch("os._exit") as mock_os_exit,
             ):
                 loop = asyncio.get_running_loop()
@@ -403,7 +395,6 @@ class TestDoubleSignalForceExit:
 
             with (
                 patch("corvidae.main.create_plugin_manager", return_value=mock_pm),
-                patch("corvidae.main.Agent", return_value=mock_agent),
                 patch("os._exit") as mock_os_exit,
             ):
                 loop = asyncio.get_running_loop()
@@ -451,7 +442,6 @@ class TestShutdownTimeout:
 
             with (
                 patch("corvidae.main.create_plugin_manager", return_value=mock_pm),
-                patch("corvidae.main.Agent", return_value=mock_agent),
                 patch("os._exit") as mock_os_exit,
                 patch("corvidae.main.asyncio.wait_for", side_effect=_patched_wait_for),
             ):

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -161,6 +161,7 @@ class TestOnStartWithStdioServer:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         with (
             patch("mcp.client.stdio.stdio_client", return_value=mock_stdio_cm),
             patch("mcp.client.stdio.StdioServerParameters"),
@@ -201,6 +202,7 @@ class TestOnStartWithStdioServer:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         with (
             patch("mcp.client.stdio.stdio_client", return_value=mock_stdio_cm),
             patch("mcp.client.stdio.StdioServerParameters"),
@@ -243,6 +245,7 @@ class TestOnStartWithStdioServer:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         with (
             patch("mcp.client.stdio.stdio_client", return_value=mock_stdio_cm),
             patch("mcp.client.stdio.StdioServerParameters"),
@@ -322,6 +325,7 @@ class TestOnStartWithSseServer:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         with (
             patch("mcp.client.sse.sse_client", return_value=mock_sse_cm),
             patch("mcp.ClientSession", return_value=mock_client_session_cm),
@@ -356,6 +360,7 @@ class TestOnStartUnknownTransport:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         with caplog.at_level(logging.WARNING, logger="corvidae.mcp_client"):
             # Should not raise.
             await plugin.on_start(config=config)

--- a/tests/test_parameterized_config.py
+++ b/tests/test_parameterized_config.py
@@ -209,6 +209,7 @@ class TestCoreToolsReadsConfig:
             }
         }
 
+        await plugin.on_init(pm=MagicMock(), config=config)
         # Patch aiohttp.ClientSession to avoid a real HTTP connection.
         mock_session = MagicMock()
         mock_session.close = AsyncMock()
@@ -273,10 +274,10 @@ class TestCompactionPlugin:
         )
 
     async def test_compaction_plugin_reads_config(self):
-        """CompactionPlugin.on_start reads agent config."""
+        """CompactionPlugin.on_init reads agent config."""
         from corvidae.compaction import CompactionPlugin
 
-        plugin = CompactionPlugin(None)
+        plugin = CompactionPlugin()
         config = {
             "agent": {
                 "compaction_threshold": 0.9,
@@ -286,7 +287,7 @@ class TestCompactionPlugin:
             }
         }
 
-        await plugin.on_start(config=config)
+        await plugin.on_init(pm=MagicMock(), config=config)
 
         assert plugin._compaction_threshold == 0.9, (
             f"Expected _compaction_threshold=0.9, got {plugin._compaction_threshold!r}"
@@ -470,7 +471,7 @@ class TestTaskConstants:
 
 class TestIRCMessageChunkSizeFromConfig:
     async def test_irc_message_chunk_size_from_config(self):
-        """IRCPlugin reads irc.message_chunk_size in on_start."""
+        """IRCPlugin reads irc.message_chunk_size in on_init."""
         # Import IRCPlugin here so corvidae.channels.irc is cached in sys.modules
         # before any patching; this ensures patch("corvidae.channels.irc.get_dependency")
         # targets the same module instance that IRCPlugin closes over.
@@ -480,16 +481,19 @@ class TestIRCMessageChunkSizeFromConfig:
         pm_mock = MagicMock()
         registry_mock = MagicMock(spec=ChannelRegistry)
 
+        config = {
+            "irc": {
+                "host": "localhost",
+                "nick": "bot",
+                "message_chunk_size": 200,
+            }
+        }
+
         with patch("corvidae.channels.irc.get_dependency", return_value=registry_mock), \
              patch("asyncio.create_task"):
             plugin = IRCPlugin(pm_mock)
-            await plugin.on_start(config={
-                "irc": {
-                    "host": "localhost",
-                    "nick": "bot",
-                    "message_chunk_size": 200,
-                }
-            })
+            await plugin.on_init(pm=pm_mock, config=config)
+            await plugin.on_start(config=config)
 
         assert hasattr(plugin, "_message_chunk_size"), (
             "IRCPlugin must store _message_chunk_size after on_start"
@@ -593,8 +597,10 @@ class TestTaskPluginCompletedBuffer:
         pm_mock = MagicMock()
         plugin = TaskPlugin(pm_mock)
 
+        config = {"daemon": {"completed_task_buffer": 42}}
+        await plugin.on_init(pm=pm_mock, config=config)
         with patch("asyncio.create_task"):
-            await plugin.on_start(config={"daemon": {"completed_task_buffer": 42}})
+            await plugin.on_start(config=config)
 
         assert plugin.task_queue is not None, "TaskPlugin.task_queue must be set after on_start"
         assert plugin.task_queue.completed.maxlen == 42, (

--- a/tests/test_part5_rename.py
+++ b/tests/test_part5_rename.py
@@ -46,14 +46,21 @@ def test_agent_has_expected_attributes():
 # ---------------------------------------------------------------------------
 
 def test_main_registers_as_agent_not_agent_loop():
-    """main.py must register the agent plugin with name='agent', not 'agent_loop'."""
-    import corvidae.main as main_module
-    source = inspect.getsource(main_module)
-    assert 'name="agent"' in source, (
-        'main.py must contain name="agent" registration'
+    """Agent must be registered under name 'agent' (via entry point), not 'agent_loop'."""
+    from importlib.metadata import entry_points
+    from corvidae.agent import Agent
+
+    # Verify the entry point registers Agent under name 'agent'
+    eps = {ep.name: ep for ep in entry_points(group="corvidae")}
+    assert "agent" in eps, (
+        "Entry point group 'corvidae' must have an 'agent' entry"
     )
-    assert 'name="agent_loop"' not in source, (
-        'main.py must not use name="agent_loop" after the rename'
+    assert "agent_loop" not in eps, (
+        "Entry point group 'corvidae' must not have an 'agent_loop' entry"
+    )
+    loaded = eps["agent"].load()
+    assert loaded is Agent, (
+        f"Entry point 'agent' must load corvidae.agent.Agent, got {loaded!r}"
     )
 
 

--- a/tests/test_plugin_cleanup.py
+++ b/tests/test_plugin_cleanup.py
@@ -1,0 +1,585 @@
+"""Tests for the plugin registration refactor (entry points + on_init hook).
+
+These tests cover:
+1. on_init hookspec on AgentSpec
+2. CorvidaePlugin base class in corvidae.hooks
+3. No-arg constructors for all 16 entry-point plugins
+4. CorvidaePlugin subclassing for each plugin
+5. Entry points registered in the "corvidae" group
+6. RuntimeSettingsPlugin.on_init extends blocklist from config
+7. DreamPlugin.on_start and on_idle have @hookimpl decorators
+
+All tests FAIL until the implementation is complete.
+"""
+
+import pytest
+
+from corvidae.hooks import AgentSpec, create_plugin_manager
+
+
+# ---------------------------------------------------------------------------
+# 1. on_init hookspec on AgentSpec
+# ---------------------------------------------------------------------------
+
+
+def test_agentspec_has_on_init():
+    """AgentSpec must have an on_init hookspec."""
+    assert hasattr(AgentSpec, "on_init"), (
+        "AgentSpec must have an on_init hookspec"
+    )
+
+
+async def test_on_init_hookspec_is_callable_via_pm():
+    """on_init must be dispatchable via pm.ahook.on_init without error."""
+
+    class _Listener:
+        from corvidae.hooks import hookimpl
+
+        @hookimpl
+        async def on_init(self, pm, config):
+            self.got_pm = pm
+            self.got_config = config
+
+    pm = create_plugin_manager()
+    listener = _Listener()
+    pm.register(listener)
+    await pm.ahook.on_init(pm=pm, config={"key": "value"})
+
+    assert listener.got_pm is pm
+    assert listener.got_config == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# 2. CorvidaePlugin base class
+# ---------------------------------------------------------------------------
+
+
+def test_corvidae_plugin_exists_in_hooks():
+    """CorvidaePlugin must be importable from corvidae.hooks."""
+    from corvidae.hooks import CorvidaePlugin  # noqa: F401
+
+
+def test_corvidae_plugin_depends_on_is_frozenset():
+    """CorvidaePlugin.depends_on must be a frozenset."""
+    from corvidae.hooks import CorvidaePlugin
+
+    plugin = CorvidaePlugin()
+    assert isinstance(plugin.depends_on, frozenset), (
+        "CorvidaePlugin.depends_on must be a frozenset, not "
+        f"{type(plugin.depends_on).__name__}"
+    )
+
+
+async def test_corvidae_plugin_on_init_stores_pm_and_config():
+    """CorvidaePlugin.on_init must store pm and config as instance attributes."""
+    from corvidae.hooks import CorvidaePlugin
+
+    pm = create_plugin_manager()
+    plugin = CorvidaePlugin()
+    pm.register(plugin)
+    await plugin.on_init(pm=pm, config={"section": "data"})
+
+    assert plugin.pm is pm, "CorvidaePlugin.on_init must set self.pm"
+    assert plugin.config == {"section": "data"}, (
+        "CorvidaePlugin.on_init must set self.config"
+    )
+
+
+def test_corvidae_plugin_on_init_has_hookimpl():
+    """CorvidaePlugin.on_init must be decorated with @hookimpl."""
+    from corvidae.hooks import CorvidaePlugin, hookimpl
+    import pluggy
+
+    marker_attr = hookimpl.project_name + "_impl"  # "corvidae_impl"
+    impl_opts = getattr(CorvidaePlugin.on_init, marker_attr, None)
+    assert impl_opts is not None, (
+        "CorvidaePlugin.on_init must be decorated with @hookimpl"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. No-arg constructors for entry-point plugins
+#    (ChannelRegistry is intentionally excluded per the design)
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_plugin_no_arg_constructor():
+    """PersistencePlugin() must work with no arguments."""
+    from corvidae.persistence import PersistencePlugin
+    plugin = PersistencePlugin()
+    assert plugin is not None
+
+
+def test_jsonl_log_plugin_no_arg_constructor():
+    """JsonlLogPlugin() must work with no arguments."""
+    from corvidae.jsonl_log import JsonlLogPlugin
+    plugin = JsonlLogPlugin()
+    assert plugin is not None
+
+
+def test_core_tools_plugin_no_arg_constructor():
+    """CoreToolsPlugin() must work with no arguments."""
+    from corvidae.tools import CoreToolsPlugin
+    plugin = CoreToolsPlugin()
+    assert plugin is not None
+
+
+def test_cli_plugin_no_arg_constructor():
+    """CLIPlugin() must work with no arguments."""
+    from corvidae.channels.cli import CLIPlugin
+    plugin = CLIPlugin()
+    assert plugin is not None
+
+
+def test_irc_plugin_no_arg_constructor():
+    """IRCPlugin() must work with no arguments."""
+    from corvidae.channels.irc import IRCPlugin
+    plugin = IRCPlugin()
+    assert plugin is not None
+
+
+def test_task_plugin_no_arg_constructor():
+    """TaskPlugin() must work with no arguments."""
+    from corvidae.task import TaskPlugin
+    plugin = TaskPlugin()
+    assert plugin is not None
+
+
+def test_subagent_plugin_no_arg_constructor():
+    """SubagentPlugin() must work with no arguments."""
+    from corvidae.tools.subagent import SubagentPlugin
+    plugin = SubagentPlugin()
+    assert plugin is not None
+
+
+def test_mcp_client_plugin_no_arg_constructor():
+    """McpClientPlugin() must work with no arguments."""
+    from corvidae.mcp_client import McpClientPlugin
+    plugin = McpClientPlugin()
+    assert plugin is not None
+
+
+def test_llm_plugin_no_arg_constructor():
+    """LLMPlugin() must work with no arguments."""
+    from corvidae.llm_plugin import LLMPlugin
+    plugin = LLMPlugin()
+    assert plugin is not None
+
+
+def test_compaction_plugin_no_arg_constructor():
+    """CompactionPlugin() must work with no arguments."""
+    from corvidae.compaction import CompactionPlugin
+    plugin = CompactionPlugin()
+    assert plugin is not None
+
+
+def test_thinking_plugin_no_arg_constructor():
+    """ThinkingPlugin() must work with no arguments."""
+    from corvidae.thinking import ThinkingPlugin
+    plugin = ThinkingPlugin()
+    assert plugin is not None
+
+
+def test_runtime_settings_plugin_no_arg_constructor():
+    """RuntimeSettingsPlugin() must work with no arguments."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+    plugin = RuntimeSettingsPlugin()
+    assert plugin is not None
+
+
+def test_tool_collection_plugin_no_arg_constructor():
+    """ToolCollectionPlugin() must work with no arguments."""
+    from corvidae.tool_collection import ToolCollectionPlugin
+    plugin = ToolCollectionPlugin()
+    assert plugin is not None
+
+
+def test_dream_plugin_no_arg_constructor():
+    """DreamPlugin() must work with no arguments."""
+    from corvidae.tools.dream import DreamPlugin
+    plugin = DreamPlugin()
+    assert plugin is not None
+
+
+def test_agent_no_arg_constructor():
+    """Agent() must work with no arguments."""
+    from corvidae.agent import Agent
+    plugin = Agent()
+    assert plugin is not None
+
+
+def test_idle_monitor_plugin_no_arg_constructor():
+    """IdleMonitorPlugin() must work with no arguments."""
+    from corvidae.idle import IdleMonitorPlugin
+    plugin = IdleMonitorPlugin()
+    assert plugin is not None
+
+
+def test_channel_registry_no_arg_constructor():
+    """ChannelRegistry() must work with no arguments (agent_defaults defaults to {})."""
+    from corvidae.channel import ChannelRegistry
+    registry = ChannelRegistry()
+    assert registry.agent_defaults == {}
+
+
+# ---------------------------------------------------------------------------
+# 4. CorvidaePlugin subclassing
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.persistence import PersistencePlugin
+    assert issubclass(PersistencePlugin, CorvidaePlugin), (
+        "PersistencePlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_jsonl_log_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.jsonl_log import JsonlLogPlugin
+    assert issubclass(JsonlLogPlugin, CorvidaePlugin), (
+        "JsonlLogPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_core_tools_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.tools import CoreToolsPlugin
+    assert issubclass(CoreToolsPlugin, CorvidaePlugin), (
+        "CoreToolsPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_cli_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.channels.cli import CLIPlugin
+    assert issubclass(CLIPlugin, CorvidaePlugin), (
+        "CLIPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_irc_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.channels.irc import IRCPlugin
+    assert issubclass(IRCPlugin, CorvidaePlugin), (
+        "IRCPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_task_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.task import TaskPlugin
+    assert issubclass(TaskPlugin, CorvidaePlugin), (
+        "TaskPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_subagent_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.tools.subagent import SubagentPlugin
+    assert issubclass(SubagentPlugin, CorvidaePlugin), (
+        "SubagentPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_mcp_client_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.mcp_client import McpClientPlugin
+    assert issubclass(McpClientPlugin, CorvidaePlugin), (
+        "McpClientPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_llm_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.llm_plugin import LLMPlugin
+    assert issubclass(LLMPlugin, CorvidaePlugin), (
+        "LLMPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_compaction_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.compaction import CompactionPlugin
+    assert issubclass(CompactionPlugin, CorvidaePlugin), (
+        "CompactionPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_thinking_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.thinking import ThinkingPlugin
+    assert issubclass(ThinkingPlugin, CorvidaePlugin), (
+        "ThinkingPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_runtime_settings_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+    assert issubclass(RuntimeSettingsPlugin, CorvidaePlugin), (
+        "RuntimeSettingsPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_tool_collection_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.tool_collection import ToolCollectionPlugin
+    assert issubclass(ToolCollectionPlugin, CorvidaePlugin), (
+        "ToolCollectionPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_dream_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.tools.dream import DreamPlugin
+    assert issubclass(DreamPlugin, CorvidaePlugin), (
+        "DreamPlugin must subclass CorvidaePlugin"
+    )
+
+
+def test_agent_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.agent import Agent
+    assert issubclass(Agent, CorvidaePlugin), (
+        "Agent must subclass CorvidaePlugin"
+    )
+
+
+def test_idle_monitor_plugin_subclasses_corvidae_plugin():
+    from corvidae.hooks import CorvidaePlugin
+    from corvidae.idle import IdleMonitorPlugin
+    assert issubclass(IdleMonitorPlugin, CorvidaePlugin), (
+        "IdleMonitorPlugin must subclass CorvidaePlugin"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Entry points registered in the "corvidae" group
+# ---------------------------------------------------------------------------
+
+
+def test_corvidae_entry_point_group_exists():
+    """The 'corvidae' entry point group must exist after uv sync."""
+    from importlib.metadata import entry_points
+    eps = entry_points(group="corvidae")
+    assert len(eps) > 0, (
+        "No entry points found in 'corvidae' group. "
+        "Run 'uv sync' and ensure [project.entry-points.corvidae] is in pyproject.toml."
+    )
+
+
+def test_corvidae_entry_points_contain_expected_names():
+    """The 'corvidae' entry point group must contain all 16 expected plugin names."""
+    from importlib.metadata import entry_points
+    eps = entry_points(group="corvidae")
+    names = {ep.name for ep in eps}
+
+    expected = {
+        "persistence",
+        "jsonl_log",
+        "core_tools",
+        "cli",
+        "irc",
+        "task",
+        "subagent",
+        "mcp",
+        "llm",
+        "compaction",
+        "thinking",
+        "runtime_settings",
+        "tools",
+        "dream",
+        "agent",
+        "idle_monitor",
+    }
+    missing = expected - names
+    assert not missing, (
+        f"Entry point group 'corvidae' is missing: {sorted(missing)}"
+    )
+
+
+def test_corvidae_entry_points_load_correct_classes():
+    """Each entry point must load the correct plugin class."""
+    from importlib.metadata import entry_points
+
+    expected_map = {
+        "persistence": "corvidae.persistence:PersistencePlugin",
+        "jsonl_log": "corvidae.jsonl_log:JsonlLogPlugin",
+        "core_tools": "corvidae.tools:CoreToolsPlugin",
+        "cli": "corvidae.channels.cli:CLIPlugin",
+        "irc": "corvidae.channels.irc:IRCPlugin",
+        "task": "corvidae.task:TaskPlugin",
+        "subagent": "corvidae.tools.subagent:SubagentPlugin",
+        "mcp": "corvidae.mcp_client:McpClientPlugin",
+        "llm": "corvidae.llm_plugin:LLMPlugin",
+        "compaction": "corvidae.compaction:CompactionPlugin",
+        "thinking": "corvidae.thinking:ThinkingPlugin",
+        "runtime_settings": "corvidae.tools.settings:RuntimeSettingsPlugin",
+        "tools": "corvidae.tool_collection:ToolCollectionPlugin",
+        "dream": "corvidae.tools.dream:DreamPlugin",
+        "agent": "corvidae.agent:Agent",
+        "idle_monitor": "corvidae.idle:IdleMonitorPlugin",
+    }
+
+    eps = {ep.name: ep for ep in entry_points(group="corvidae")}
+    errors = []
+    for name, expected_value in expected_map.items():
+        if name not in eps:
+            errors.append(f"{name!r}: not found in entry points")
+            continue
+        ep = eps[name]
+        actual_value = ep.value
+        if actual_value != expected_value:
+            errors.append(
+                f"{name!r}: expected {expected_value!r}, got {actual_value!r}"
+            )
+
+    assert not errors, "Entry point value mismatches:\n" + "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# 6. RuntimeSettingsPlugin.on_init extends blocklist from config
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_settings_plugin_default_blocklist():
+    """RuntimeSettingsPlugin() must initialise blocklist with 'system_prompt'."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+
+    plugin = RuntimeSettingsPlugin()
+    assert "system_prompt" in plugin.blocklist, (
+        "RuntimeSettingsPlugin.__init__ must set blocklist to include 'system_prompt'"
+    )
+
+
+async def test_runtime_settings_plugin_on_init_extends_blocklist():
+    """RuntimeSettingsPlugin.on_init must extend blocklist from config immutable_settings."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+
+    pm = create_plugin_manager()
+    plugin = RuntimeSettingsPlugin()
+    pm.register(plugin, name="runtime_settings")
+    await plugin.on_init(
+        pm=pm,
+        config={"agent": {"immutable_settings": ["max_turns", "max_context_tokens"]}},
+    )
+
+    assert "system_prompt" in plugin.blocklist, (
+        "system_prompt must remain in blocklist after on_init"
+    )
+    assert "max_turns" in plugin.blocklist, (
+        "max_turns must be added to blocklist via on_init config"
+    )
+    assert "max_context_tokens" in plugin.blocklist, (
+        "max_context_tokens must be added to blocklist via on_init config"
+    )
+
+
+async def test_runtime_settings_plugin_on_init_empty_immutable_settings():
+    """RuntimeSettingsPlugin.on_init with empty immutable_settings leaves default blocklist."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+
+    pm = create_plugin_manager()
+    plugin = RuntimeSettingsPlugin()
+    pm.register(plugin, name="runtime_settings")
+    await plugin.on_init(pm=pm, config={})
+
+    assert "system_prompt" in plugin.blocklist, (
+        "system_prompt must remain in blocklist when immutable_settings absent from config"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. DreamPlugin @hookimpl decorators on on_start and on_idle
+# ---------------------------------------------------------------------------
+
+
+def test_dream_plugin_on_start_has_hookimpl():
+    """DreamPlugin.on_start must be decorated with @hookimpl."""
+    from corvidae.tools.dream import DreamPlugin
+    from corvidae.hooks import hookimpl
+
+    marker_attr = hookimpl.project_name + "_impl"  # "corvidae_impl"
+    impl_opts = getattr(DreamPlugin.on_start, marker_attr, None)
+    assert impl_opts is not None, (
+        "DreamPlugin.on_start must be decorated with @hookimpl — "
+        "currently missing, which means on_start is never dispatched by pluggy"
+    )
+
+
+def test_dream_plugin_on_idle_has_hookimpl():
+    """DreamPlugin.on_idle must be decorated with @hookimpl."""
+    from corvidae.tools.dream import DreamPlugin
+    from corvidae.hooks import hookimpl
+
+    marker_attr = hookimpl.project_name + "_impl"  # "corvidae_impl"
+    impl_opts = getattr(DreamPlugin.on_idle, marker_attr, None)
+    assert impl_opts is not None, (
+        "DreamPlugin.on_idle must be decorated with @hookimpl — "
+        "currently missing, which means on_idle is never dispatched by pluggy"
+    )
+
+
+async def test_dream_plugin_dispatched_via_pm_on_start():
+    """DreamPlugin.on_start must be called when pm.ahook.on_start is broadcast."""
+    from corvidae.tools.dream import DreamPlugin
+
+    pm = create_plugin_manager()
+    plugin = DreamPlugin()
+    plugin.workspace_root = None  # avoid Path resolution in on_start
+    pm.register(plugin)
+
+    # on_start will fail without a proper config — we only care it's called,
+    # not that it succeeds. Catch any error from missing config but verify
+    # dispatch happened by checking on_start is recognised as a hookimpl.
+    try:
+        await pm.ahook.on_start(config={})
+    except (TypeError, KeyError, AttributeError, ValueError):
+        pass  # Expected — on_start needs config; we only test dispatch registration
+
+    # If @hookimpl is missing, the hook simply never called on_start on this plugin.
+    # We verify dispatch by checking the hookimpl is registered.
+    hook_caller = pm.hook.on_start
+    impl_plugins = [impl.plugin for impl in hook_caller.get_hookimpls()]
+    assert plugin in impl_plugins, (
+        "DreamPlugin must be registered as an on_start hookimpl. "
+        "Ensure @hookimpl is applied to DreamPlugin.on_start."
+    )
+
+
+async def test_dream_plugin_dispatched_via_pm_on_idle():
+    """DreamPlugin.on_idle must be called when pm.ahook.on_idle is broadcast."""
+    from corvidae.tools.dream import DreamPlugin
+
+    pm = create_plugin_manager()
+    plugin = DreamPlugin()
+    plugin.workspace_root = None
+    plugin._db_path = None
+    plugin._last_dream_time = 0.0
+    pm.register(plugin)
+
+    hook_caller = pm.hook.on_idle
+    impl_plugins = [impl.plugin for impl in hook_caller.get_hookimpls()]
+    assert plugin in impl_plugins, (
+        "DreamPlugin must be registered as an on_idle hookimpl. "
+        "Ensure @hookimpl is applied to DreamPlugin.on_idle."
+    )
+
+
+def test_agent_on_start_does_not_have_hookimpl():
+    """Agent.on_start must NOT be decorated with @hookimpl.
+    It is called explicitly after pm.ahook.on_start() broadcast to
+    ensure ToolCollectionPlugin.on_start (trylast=True) completes first.
+    Adding @hookimpl would cause double initialization.
+    """
+    from corvidae.agent import Agent
+    from corvidae.hooks import hookimpl
+
+    marker_attr = hookimpl.project_name + "_impl"
+    impl_opts = getattr(Agent.on_start, marker_attr, None)
+    assert impl_opts is None, (
+        "Agent.on_start must NOT have @hookimpl — it is called explicitly "
+        "after the on_start broadcast to prevent double initialization"
+    )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -982,6 +982,7 @@ class TestTaskPluginConfig:
         plugin = TaskPlugin(pm)
 
         config = {"daemon": {"max_task_workers": 3}}
+        await plugin.on_init(pm=pm, config=config)
         await plugin.on_start(config=config)
 
         assert plugin.task_queue is not None

--- a/tests/test_tool_collection.py
+++ b/tests/test_tool_collection.py
@@ -70,6 +70,7 @@ async def test_tool_collection_plugin_reads_tools_max_result_chars():
     pm.hook.register_tools = MagicMock(return_value=[])
     plugin = ToolCollectionPlugin(pm)
     config = {"tools": {"max_result_chars": 50_000}}
+    await plugin.on_init(pm=pm, config=config)
     await plugin.on_start(config=config)
     assert plugin.max_result_chars == 50_000
 
@@ -86,6 +87,7 @@ async def test_tool_collection_plugin_falls_back_to_agent_max_tool_result_chars(
     pm.hook.register_tools = MagicMock(return_value=[])
     plugin = ToolCollectionPlugin(pm)
     config = {"agent": {"max_tool_result_chars": 75_000}}
+    await plugin.on_init(pm=pm, config=config)
     await plugin.on_start(config=config)
     assert plugin.max_result_chars == 75_000
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -340,7 +340,10 @@ class TestCoreToolsPlugin:
 
         plugin2 = CoreToolsPlugin(None)
         import asyncio
-        asyncio.run(plugin2.on_start(config={"tools": {"web_search_max_results": 15}}))
+        from unittest.mock import MagicMock
+        config = {"tools": {"web_search_max_results": 15}}
+        asyncio.run(plugin2.on_init(pm=MagicMock(), config=config))
+        asyncio.run(plugin2.on_start(config=config))
         try:
             assert plugin2._web_search_max_results == 15
         finally:


### PR DESCRIPTION
Replace 17 hardcoded plugin imports in main.py with setuptools entry point loading. Add on_init hookspec to AgentSpec for config/wiring injection, and CorvidaePlugin base class that stores pm and config.

All plugins now have no-arg constructors and subclass CorvidaePlugin. Config reading moves from on_start to on_init; runtime resource creation stays in on_start. ChannelRegistry remains a plain class, constructed explicitly in main.py before entry point loading.

Also fixes a pre-existing bug: DreamPlugin.on_start and on_idle lacked @hookimpl decorators and were never dispatched by pluggy.