### PR TITLE
Add plugin scaffolding tool for generating new corvidae packages

### DIFF
--- a/corvidae/main.py
+++ b/corvidae/main.py
@@ -134,5 +134,13 @@ async def _run_shutdown(agent: object, pm: pluggy.PluginManager) -> None:
 
 
 def cli() -> None:
-    """Console script entry point."""
-    asyncio.run(main(cli_mode=True))
+    """Console script entry point.
+
+    Dispatches to sub-commands before starting the daemon:
+      corvidae scaffold <name>   — generate a new tool plugin package
+    """
+    if len(sys.argv) > 1 and sys.argv[1] == "scaffold":
+        from corvidae.scaffold import scaffold_cli
+        scaffold_cli(sys.argv[2:])
+    else:
+        asyncio.run(main(cli_mode=True))

--- a/corvidae/scaffold.py
+++ b/corvidae/scaffold.py
@@ -1,0 +1,180 @@
+"""Scaffold a new corvidae tool plugin package.
+
+Generates a ready-to-install Python package with:
+  - pyproject.toml (corvidae dependency + entry point)
+  - Plugin module implementing register_tools
+  - tests/conftest.py with plugin_manager fixture
+  - tests/test_<pkg>.py with basic fixture wiring
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _to_package_name(dist_name: str) -> str:
+    return dist_name.replace("-", "_")
+
+
+def _to_class_name(dist_name: str) -> str:
+    return "".join(part.capitalize() for part in dist_name.replace("-", "_").split("_"))
+
+
+def _to_entry_point_name(dist_name: str) -> str:
+    parts = dist_name.replace("-", "_").split("_")
+    if parts[-1] in ("plugin", "tools"):
+        parts = parts[:-1]
+    return "_".join(parts)
+
+
+_PYPROJECT_TEMPLATE = """\
+[project]
+name = "{dist_name}"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "corvidae",
+]
+
+[project.entry-points.corvidae]
+{ep_name} = "{pkg}:{cls}"
+
+[tool.setuptools.packages.find]
+include = ["{pkg}*"]
+
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+"""
+
+_PLUGIN_TEMPLATE = """\
+from corvidae.hooks import CorvidaePlugin, hookimpl
+from corvidae.tool import Tool
+
+
+class {cls}(CorvidaePlugin):
+    @hookimpl
+    def register_tools(self, tool_registry: list) -> None:
+        async def my_tool(input: str) -> str:
+            \"\"\"TODO: describe what this tool does.\"\"\"
+            raise NotImplementedError("Implement me")
+
+        tool_registry.append(Tool.from_function(my_tool))
+"""
+
+_CONFTEST_TEMPLATE = """\
+import pytest
+from corvidae.hooks import create_plugin_manager
+
+
+@pytest.fixture
+def plugin_manager():
+    return create_plugin_manager()
+"""
+
+_TEST_TEMPLATE = """\
+import pytest
+from unittest.mock import MagicMock
+
+from {pkg} import {cls}
+
+
+def test_plugin_importable():
+    from {pkg} import {cls}  # noqa: F401
+
+
+def test_plugin_instantiable():
+    plugin = {cls}()
+    assert plugin is not None
+
+
+def test_register_tools():
+    plugin = {cls}()
+    registry = []
+    plugin.register_tools(registry)
+    assert len(registry) > 0
+
+
+async def test_register_tools_via_pluginmanager(plugin_manager):
+    plugin = {cls}()
+    plugin_manager.register(plugin, name="{ep_name}")
+    registry = []
+    plugin_manager.hook.register_tools(tool_registry=registry)
+    assert len(registry) > 0
+"""
+
+
+def scaffold(dist_name: str, output_dir: Path) -> None:
+    """Generate a plugin package directory tree under output_dir."""
+    pkg = _to_package_name(dist_name)
+    cls = _to_class_name(dist_name)
+    ep_name = _to_entry_point_name(dist_name)
+
+    root = output_dir / dist_name
+    root.mkdir(parents=True, exist_ok=True)
+    (root / pkg).mkdir(exist_ok=True)
+    (root / "tests").mkdir(exist_ok=True)
+
+    _write(root / "pyproject.toml", _PYPROJECT_TEMPLATE.format(dist_name=dist_name, pkg=pkg, cls=cls, ep_name=ep_name))
+    _write(root / pkg / "__init__.py", _PLUGIN_TEMPLATE.format(cls=cls))
+    _write(root / "tests" / "conftest.py", _CONFTEST_TEMPLATE)
+    _write(root / "tests" / f"test_{pkg}.py", _TEST_TEMPLATE.format(pkg=pkg, cls=cls, ep_name=ep_name))
+
+    created = [
+        f"  {dist_name}/pyproject.toml",
+        f"  {dist_name}/{pkg}/__init__.py",
+        f"  {dist_name}/tests/conftest.py",
+        f"  {dist_name}/tests/test_{pkg}.py",
+    ]
+    print(f"Scaffolded plugin package: {root}/")
+    print("\n".join(created))
+    print()
+    print("Next steps:")
+    print(f"  cd {root}")
+    print( "  pip install -e .")
+    print(f"  # Edit {pkg}/__init__.py to implement your tools")
+    print( "  pytest")
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def scaffold_cli(args: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="corvidae scaffold",
+        description="Generate a new corvidae tool plugin package.",
+    )
+    parser.add_argument(
+        "name",
+        help="Distribution name for the new plugin (e.g. my-tool-plugin)",
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        default=".",
+        metavar="DIR",
+        help="Parent directory for the generated package tree (default: .)",
+    )
+    ns = parser.parse_args(args)
+
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9_-]*$", ns.name):
+        print(
+            f"Error: invalid name {ns.name!r} — must start with a letter and"
+            " contain only letters, digits, hyphens, or underscores.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    scaffold(ns.name, Path(ns.output_dir))

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,135 @@
+"""Tests for corvidae.scaffold — plugin package generation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from corvidae.scaffold import (
+    _to_class_name,
+    _to_entry_point_name,
+    _to_package_name,
+    scaffold,
+)
+
+
+# ---------------------------------------------------------------------------
+# Name-munging helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dist_name,expected", [
+    ("my-tool-plugin", "my_tool_plugin"),
+    ("corvidae-weather", "corvidae_weather"),
+    ("simple", "simple"),
+])
+def test_to_package_name(dist_name, expected):
+    assert _to_package_name(dist_name) == expected
+
+
+@pytest.mark.parametrize("dist_name,expected", [
+    ("my-tool-plugin", "MyToolPlugin"),
+    ("corvidae-weather", "CorvidaeWeather"),
+    ("simple", "Simple"),
+])
+def test_to_class_name(dist_name, expected):
+    assert _to_class_name(dist_name) == expected
+
+
+@pytest.mark.parametrize("dist_name,expected", [
+    ("my-tool-plugin", "my_tool"),    # strips trailing "plugin"
+    ("corvidae-weather-tools", "corvidae_weather"),  # strips trailing "tools"
+    ("weather", "weather"),            # no suffix to strip
+])
+def test_to_entry_point_name(dist_name, expected):
+    assert _to_entry_point_name(dist_name) == expected
+
+
+# ---------------------------------------------------------------------------
+# File generation
+# ---------------------------------------------------------------------------
+
+def test_scaffold_creates_expected_files(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+
+    root = tmp_path / "my-tool-plugin"
+    assert (root / "pyproject.toml").exists()
+    assert (root / "my_tool_plugin" / "__init__.py").exists()
+    assert (root / "tests" / "conftest.py").exists()
+    assert (root / "tests" / "test_my_tool_plugin.py").exists()
+
+
+def test_scaffold_pyproject_contains_entry_point(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    content = (tmp_path / "my-tool-plugin" / "pyproject.toml").read_text()
+    assert 'my_tool = "my_tool_plugin:MyToolPlugin"' in content
+    assert 'corvidae' in content
+
+
+def test_scaffold_pyproject_contains_corvidae_dependency(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    content = (tmp_path / "my-tool-plugin" / "pyproject.toml").read_text()
+    assert '"corvidae"' in content
+
+
+def test_scaffold_plugin_module_contains_class(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    content = (tmp_path / "my-tool-plugin" / "my_tool_plugin" / "__init__.py").read_text()
+    assert "class MyToolPlugin(CorvidaePlugin):" in content
+    assert "register_tools" in content
+    assert "Tool.from_function" in content
+
+
+def test_scaffold_test_file_imports_plugin(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    content = (tmp_path / "my-tool-plugin" / "tests" / "test_my_tool_plugin.py").read_text()
+    assert "from my_tool_plugin import MyToolPlugin" in content
+    assert "def test_register_tools" in content
+
+
+def test_scaffold_conftest_has_plugin_manager_fixture(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    content = (tmp_path / "my-tool-plugin" / "tests" / "conftest.py").read_text()
+    assert "create_plugin_manager" in content
+    assert "def plugin_manager" in content
+
+
+def test_scaffold_idempotent(tmp_path):
+    scaffold("my-tool-plugin", tmp_path)
+    scaffold("my-tool-plugin", tmp_path)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# CLI validation
+# ---------------------------------------------------------------------------
+
+def test_scaffold_cli_rejects_invalid_name():
+    result = subprocess.run(
+        [sys.executable, "-m", "corvidae.scaffold_runner", "123-bad"],
+        capture_output=True, text=True,
+    )
+    # The scaffold_cli function raises SystemExit on invalid name; we test it
+    # via the public API instead.
+    from corvidae.scaffold import scaffold_cli
+    with pytest.raises(SystemExit) as exc_info:
+        scaffold_cli(["123-bad"])
+    assert exc_info.value.code != 0
+
+
+def test_scaffold_cli_generates_package(tmp_path):
+    from corvidae.scaffold import scaffold_cli
+    scaffold_cli(["my-weather-plugin", "--output-dir", str(tmp_path)])
+    assert (tmp_path / "my-weather-plugin" / "pyproject.toml").exists()
+
+
+def test_corvidae_scaffold_subcommand(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-c",
+         f"import sys; sys.argv = ['corvidae', 'scaffold', 'demo-plugin', '--output-dir', {str(tmp_path)!r}];"
+         "from corvidae.main import cli; cli()"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "demo-plugin" / "pyproject.toml").exists()


### PR DESCRIPTION
## Summary
This PR adds a `corvidae scaffold` subcommand that generates a ready-to-install Python package template for creating new corvidae tool plugins. This reduces boilerplate and provides a consistent structure for plugin development.

## Key Changes
- **New `corvidae/scaffold.py` module**: Implements plugin package generation with:
  - Name munging utilities to convert distribution names to Python identifiers (package names, class names, entry point names)
  - Template-based file generation for `pyproject.toml`, plugin module, and test files
  - `scaffold()` function to create the full directory tree
  - `scaffold_cli()` function to handle command-line argument parsing and validation
  
- **Updated `corvidae/main.py`**: Modified the `cli()` entry point to dispatch to `scaffold_cli()` when the first argument is `"scaffold"`, allowing invocation via `corvidae scaffold <name>`

- **Comprehensive test suite in `tests/test_scaffold.py`**: 
  - Unit tests for name-munging helper functions
  - Integration tests verifying generated file structure and content
  - CLI validation tests
  - End-to-end test of the subcommand integration

## Implementation Details
- Generated packages include:
  - `pyproject.toml` with corvidae dependency and entry point configuration
  - Plugin module implementing `CorvidaePlugin` with a stub `register_tools()` method
  - Test fixtures and basic test cases for plugin validation
  - Development dependencies (pytest, pytest-asyncio)
  
- Name conversion handles common patterns:
  - Hyphens converted to underscores for Python identifiers
  - CamelCase class names derived from distribution names
  - Entry point names automatically strip trailing "plugin" or "tools" suffixes
  
- Input validation ensures distribution names follow Python packaging conventions (start with letter, contain only alphanumerics, hyphens, underscores)

https://claude.ai/code/session_01Ab2HHgFCt6czJEudrvtpNF