### PR TITLE
feat: hot-reload agent.yaml without daemon restart

### DIFF
--- a/corvidae/agent.py
+++ b/corvidae/agent.py
@@ -684,6 +684,29 @@ class Agent(CorvidaePlugin):
         self._tools, self._tool_schemas = tools_plugin.get_tools()
         self._max_tool_result_chars = tools_plugin.max_result_chars
 
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        """Re-read agent config and re-borrow the LLM client from LLMPlugin.
+
+        Re-borrows _client because LLMPlugin may have swapped its main_client
+        during this same reload cycle (Key Design Decision #3 in design doc).
+        System prompt changes take effect only on new conversations (existing
+        conversations retain their current ContextWindow.system_prompt).
+        """
+        # Re-read agent config values.
+        agent_config = config.get("agent", {})
+        self._chars_per_token = agent_config.get("chars_per_token", DEFAULT_CHARS_PER_TOKEN)
+        daemon_config = config.get("daemon", {})
+        self._idle_cooldown = daemon_config.get("idle_cooldown_seconds", 30.0)
+
+        # Re-borrow the LLM client from LLMPlugin after a possible swap.
+        # Avoids isinstance check so MagicMock(spec=LLMPlugin) works in tests.
+        llm = self.pm.get_plugin("llm")
+        if llm is not None and hasattr(llm, "get_client"):
+            self._client = llm.get_client()
+
+        logger.info("on_config_reload: agent config updated")
+
     @hookimpl(trylast=True)
     async def on_plugin_added(self, name: str, plugin: object) -> None:
         """Refresh tools when a plugin is added at runtime.

--- a/corvidae/channel.py
+++ b/corvidae/channel.py
@@ -116,6 +116,12 @@ class Channel:
 class ChannelRegistry:
     """Manages the lifecycle of channels."""
 
+    # Class-level agent_defaults allows ConfigWatcherPlugin to update the default
+    # config globally by setting ChannelRegistry.agent_defaults = new_config.get("agent", {}).
+    # Instance __init__ sets self.agent_defaults which shadows this for existing instances;
+    # the class attribute is the target for hot-reload updates via ConfigWatcherPlugin.
+    agent_defaults: dict = {}
+
     def __init__(self, agent_defaults: dict | None = None) -> None:
         """
         Args:

--- a/corvidae/compaction.py
+++ b/corvidae/compaction.py
@@ -99,6 +99,28 @@ class CompactionPlugin(CorvidaePlugin):
                 threshold, retention, gap,
             )
 
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        """Re-read compaction thresholds and invalidate the cached LLM client.
+
+        Invalidates _llm_client so it is re-resolved from LLMPlugin on the
+        next compaction call (necessary after LLMPlugin swaps the client on reload).
+        """
+        agent_config = config.get("agent", {})
+        self._compaction_threshold = agent_config.get("compaction_threshold", 0.8)
+        self._compaction_retention = agent_config.get("compaction_retention", 0.5)
+        self._min_messages = agent_config.get("min_messages_to_compact", 5)
+        self._chars_per_token = agent_config.get("chars_per_token", DEFAULT_CHARS_PER_TOKEN)
+        self._summary_prompt = agent_config.get("compaction_prompt", self.DEFAULT_SUMMARY_PROMPT)
+
+        # Invalidate cached LLM client so it is re-borrowed from LLMPlugin.
+        # LLMPlugin may have swapped the client during this same reload cycle.
+        self._llm_client = None
+
+        self._validate_config()
+
+        logger.info("on_config_reload: compaction thresholds updated")
+
     @hookimpl(trylast=True)
     async def compact_conversation(self, channel, conversation, max_tokens):
         """Compact the conversation if it exceeds 80% of max_tokens.

--- a/corvidae/config_watcher.py
+++ b/corvidae/config_watcher.py
@@ -1,0 +1,236 @@
+"""ConfigWatcherPlugin — hot-reload agent.yaml without restarting the daemon.
+
+Polls the config file's mtime every `daemon.config_poll_interval` seconds
+(default 2.0). On change, re-parses YAML, deep-merges CLI overrides, validates,
+and dispatches `on_config_reload` to each plugin individually.
+
+Config:
+    daemon:
+      config_poll_interval: 2.0   # optional; default 2.0 seconds
+
+Reserved config keys consumed (set by Runtime):
+    _config_path: pathlib.Path — path to agent.yaml
+    _cli_overrides: dict — CLI overrides to re-apply on every reload
+
+Error handling:
+    - Invalid YAML: logged at ERROR, reload skipped.
+    - Missing file: logged at WARNING, polling continues (file may reappear).
+    - Failed validation (no llm.main): logged at ERROR, reload skipped.
+    - Per-plugin exceptions: logged at ERROR, other plugins still receive reload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import yaml
+
+from corvidae.channel import ChannelRegistry, load_channel_config
+from corvidae.hooks import CorvidaePlugin, hookimpl
+from corvidae.runtime import deep_merge
+
+logger = logging.getLogger(__name__)
+
+# Default poll interval in seconds if not specified in config.
+_DEFAULT_POLL_INTERVAL = 2.0
+
+
+class ConfigWatcherPlugin(CorvidaePlugin):
+    """Plugin that watches agent.yaml for changes and reloads config on the fly."""
+
+    depends_on = frozenset()
+
+    def __init__(self) -> None:
+        # _config_path and _cli_overrides are set in on_init from the config dict.
+        self._config_path: Path | None = None
+        self._cli_overrides: dict = {}
+        self._poll_interval: float = _DEFAULT_POLL_INTERVAL
+
+        # _last_mtime is set in on_start from the actual file stat.
+        self._last_mtime: float = 0.0
+
+        # _stop_event and _watcher_task are created in on_start.
+        self._stop_event: asyncio.Event | None = None
+        self._watcher_task: asyncio.Task | None = None
+
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        """Read config path, CLI overrides, and poll interval from config dict."""
+        await super().on_init(pm, config)
+
+        # Read reserved keys set by Runtime.start().
+        self._config_path = config.get("_config_path")
+        self._cli_overrides = config.get("_cli_overrides") or {}
+
+        # Read poll interval from daemon section; fall back to default.
+        daemon_config = config.get("daemon", {})
+        self._poll_interval = daemon_config.get("config_poll_interval", _DEFAULT_POLL_INTERVAL)
+
+    @hookimpl
+    async def on_start(self, config: dict) -> None:
+        """Initialize _last_mtime from actual file stat and launch the watch loop."""
+        if self._config_path is None:
+            logger.warning("No config_path configured; config watching disabled")
+            return
+
+        # Initialize _last_mtime to the current mtime to avoid a redundant reload
+        # on the first poll cycle (the config was just loaded by Runtime.start).
+        try:
+            self._last_mtime = self._config_path.stat().st_mtime
+        except FileNotFoundError:
+            # File missing at startup; will be logged when polling begins.
+            self._last_mtime = 0.0
+
+        # Create stop event and launch the polling task.
+        self._stop_event = asyncio.Event()
+        self._watcher_task = asyncio.create_task(self._watch_loop())
+
+    @hookimpl
+    async def on_stop(self) -> None:
+        """Cancel the watcher task and wait for it to finish."""
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+        if self._watcher_task is not None:
+            self._watcher_task.cancel()
+            try:
+                await self._watcher_task
+            except asyncio.CancelledError:
+                pass
+            self._watcher_task = None
+
+    async def _watch_loop(self) -> None:
+        """Poll the config file mtime and trigger reload when it changes.
+
+        Runs until _stop_event is set or the task is cancelled. Uses
+        `except Exception` intentionally — this does NOT catch
+        asyncio.CancelledError (a BaseException in Python 3.8+), allowing
+        task cancellation from on_stop to propagate correctly. Do not
+        "fix" this by catching BaseException.
+        """
+        while not self._stop_event.is_set():
+            try:
+                current_mtime = self._config_path.stat().st_mtime
+                if current_mtime != self._last_mtime:
+                    # Mtime changed; reload and update the stored mtime.
+                    await self._reload_config()
+                    self._last_mtime = current_mtime
+            except FileNotFoundError:
+                # Config file was deleted; log and wait for it to reappear.
+                logger.warning("config file not found: %s", self._config_path)
+            except Exception:
+                # NOTE: `except Exception` intentionally does NOT catch
+                # asyncio.CancelledError (a BaseException in Python 3.8+).
+                # This allows task cancellation from on_stop to propagate
+                # correctly. Do not "fix" this by catching BaseException.
+                logger.exception("config watcher error")
+            await asyncio.sleep(self._poll_interval)
+
+    async def _reload_config(self) -> None:
+        """Read, validate, and apply the updated config file.
+
+        Steps:
+        1. Parse YAML from disk. On failure: log ERROR, skip.
+        2. Deep-merge CLI overrides on top of the new YAML.
+        3. Validate (must be a dict with llm.main). On failure: log ERROR, skip.
+        4. Update ChannelRegistry.agent_defaults from the new agent config.
+        5. Re-run load_channel_config for new channel entries.
+        6. Dispatch on_config_reload to each plugin with per-plugin error isolation.
+        """
+        # Step 1: Parse YAML from disk.
+        try:
+            with open(self._config_path) as f:
+                raw = yaml.safe_load(f)
+        except yaml.YAMLError:
+            logger.exception("config reload failed: invalid YAML in %s", self._config_path)
+            return
+        except Exception:
+            logger.exception("config reload failed: could not read %s", self._config_path)
+            return
+
+        # Step 2: Deep-merge CLI overrides on top of new YAML.
+        if not isinstance(raw, dict):
+            logger.error(
+                "config reload failed: YAML did not produce a dict (got %s)",
+                type(raw).__name__,
+            )
+            return
+
+        new_config = deep_merge(raw, self._cli_overrides)
+
+        # Preserve the reserved keys that Runtime sets at startup.
+        new_config["_config_path"] = self._config_path
+        new_config["_cli_overrides"] = self._cli_overrides
+        if hasattr(self, "config") and self.config is not None:
+            base_dir = self.config.get("_base_dir")
+            if base_dir is not None:
+                new_config["_base_dir"] = base_dir
+
+        # Step 3: Validate — must have llm.main.
+        llm_main = new_config.get("llm", {}).get("main")
+        if not llm_main:
+            logger.error(
+                "config reload failed: llm.main is absent from %s after merge",
+                self._config_path,
+            )
+            return
+
+        # Step 4: Update agent_defaults on both the class and the registered instance.
+        # The class-level attribute is updated so that test code and any references
+        # to ChannelRegistry.agent_defaults (class-level) see the new value.
+        # The instance attribute is updated so the runtime registry reflects the change
+        # on resolve_config calls.
+        new_agent_defaults = new_config.get("agent", {})
+        ChannelRegistry.agent_defaults = new_agent_defaults
+        registry = self.pm.get_plugin("registry")
+        if registry is not None:
+            registry.agent_defaults = new_agent_defaults
+
+        # Step 5: Re-run load_channel_config to pick up new channel entries.
+        # Existing channels are NOT updated (they retain their original ChannelConfig
+        # until restart). load_channel_config is a no-op for channels that already exist.
+        try:
+            load_channel_config(new_config, registry)
+        except ValueError:
+            logger.error(
+                "config reload: load_channel_config raised ValueError; "
+                "channel config update skipped (agent defaults still applied)",
+                exc_info=True,
+            )
+
+        # Step 6: Dispatch on_config_reload to each plugin individually.
+        await self._dispatch_config_reload(new_config)
+
+    async def _dispatch_config_reload(self, config: dict) -> None:
+        """Dispatch on_config_reload to each plugin with per-plugin error isolation.
+
+        Bypasses pm.ahook to avoid asyncio.gather, which would abort all
+        remaining plugins if one raises (apluggy broadcast uses gather without
+        return_exceptions=True). Iterates hookimpls individually so that a
+        failing plugin logs an error but does not block the others.
+
+        Filters kwargs by hook_impl.argnames, matching pluggy's _multicall
+        behavior: hookimpls that omit 'config' from their signature receive
+        no arguments rather than raising TypeError.
+        """
+        hook = self.pm.hook.on_config_reload
+        hookimpls = hook.get_hookimpls()
+        caller_kwargs = {"config": config}
+
+        # Iterate in reverse (pluggy calls hookimpls in LIFO order by default).
+        for hook_impl in reversed(hookimpls):
+            # Filter caller_kwargs to only the args the hookimpl declared.
+            impl_kwargs = {
+                k: caller_kwargs[k]
+                for k in hook_impl.argnames
+                if k in caller_kwargs
+            }
+            try:
+                await hook_impl.function(**impl_kwargs)
+            except Exception:
+                logger.exception(
+                    "on_config_reload failed for plugin %s",
+                    hook_impl.plugin_name,
+                )

--- a/corvidae/hooks.py
+++ b/corvidae/hooks.py
@@ -556,3 +556,18 @@ class AgentSpec:
         Args:
             name: The registered name of the plugin that was removed.
         """
+
+    @hookspec
+    async def on_config_reload(self, config: dict) -> None:
+        """Called when agent.yaml is reloaded from disk.
+
+        Plugins should re-read their configuration from the new config dict.
+        The config dict has already been merged with CLI overrides and validated.
+
+        This hook fires on the event loop thread. Plugins must not block.
+        Errors are caught per-plugin and logged; they do not prevent other
+        plugins from receiving the update.
+
+        Args:
+            config: The full re-parsed and merged config dict.
+        """

--- a/corvidae/hot_reload.py
+++ b/corvidae/hot_reload.py
@@ -46,6 +46,11 @@ class HotReloadPlugin(CorvidaePlugin):
     async def on_init(self, pm, config: dict) -> None:
         await super().on_init(pm, config)
 
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        """Update stored config so plugins reloaded after a config change receive current values."""
+        self.config = config
+
     # ------------------------------------------------------------------
     # Public API used by tests and the manage_plugins tool
     # ------------------------------------------------------------------

--- a/corvidae/llm_plugin.py
+++ b/corvidae/llm_plugin.py
@@ -18,12 +18,22 @@ Config:
       background:     # optional — absent means use llm.main
         (same keys)
 """
+import asyncio
 import logging
 
 from corvidae.hooks import CorvidaePlugin, hookimpl
 from corvidae.llm import LLMClient
 
 logger = logging.getLogger(__name__)
+
+
+async def _close_after(client: LLMClient, delay: float = 5.0) -> None:
+    """Close an old LLM client after a delay, allowing in-flight requests to finish."""
+    await asyncio.sleep(delay)
+    try:
+        await client.stop()
+    except Exception:
+        logger.warning("failed to close old LLM client", exc_info=True)
 
 
 class LLMPlugin(CorvidaePlugin):
@@ -68,6 +78,42 @@ class LLMPlugin(CorvidaePlugin):
             await self.main_client.stop()
         if self.background_client:
             await self.background_client.stop()
+
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        """Re-read llm config and swap main_client if it changed.
+
+        Compares the new llm.main dict with the stored one. If changed,
+        creates a new LLMClient, starts its session, and swaps the reference.
+        The old client is closed asynchronously after a delay to allow
+        in-flight requests to complete.
+        """
+        llm_config = config.get("llm", {})
+        new_main_config = llm_config.get("main")
+        if new_main_config is None:
+            # Validation should have caught this; log and skip.
+            logger.error("on_config_reload: llm.main missing from new config, skipping LLM swap")
+            return
+
+        # Compare new config with stored config; skip swap if unchanged.
+        if new_main_config == self._main_config:
+            return
+
+        logger.info("on_config_reload: llm.main changed, creating new LLM client")
+
+        # Create and start new client before swapping so that an error during
+        # start does not leave the plugin with a None client.
+        new_client = self._create_client(new_main_config)
+        await new_client.start()
+
+        # Swap the reference and store the updated config.
+        old_client = self.main_client
+        self.main_client = new_client
+        self._main_config = new_main_config
+
+        # Schedule deferred closure of the old client so in-flight requests finish.
+        if old_client is not None:
+            asyncio.create_task(_close_after(old_client, delay=5.0))
 
     def get_client(self, role: str = "main") -> LLMClient:
         """Return the client for the given role.

--- a/corvidae/runtime.py
+++ b/corvidae/runtime.py
@@ -94,8 +94,13 @@ class Runtime:
         # 2. Deep-merge overrides
         config = deep_merge(config, self.overrides)
 
-        # 3. Set _base_dir after merge — cannot be overridden
+        # 3. Set reserved keys after merge — cannot be overridden via YAML.
+        # _base_dir: parent directory of config_path for resolving relative paths.
+        # _config_path: Path to the config file, used by ConfigWatcherPlugin to poll for changes.
+        # _cli_overrides: CLI overrides dict, re-applied on every config reload.
         config["_base_dir"] = Path(self.config_path).parent
+        config["_config_path"] = Path(self.config_path)
+        config["_cli_overrides"] = self.overrides
 
         # 4. Configure logging — must be first operational step
         log_section = config.get("logging", {})

--- a/corvidae/tools/settings.py
+++ b/corvidae/tools/settings.py
@@ -31,15 +31,33 @@ class RuntimeSettingsPlugin(CorvidaePlugin):
         # immutable_settings keyword arg so existing test code still works.
         if pm is not None:
             self.pm = pm
-        self.blocklist: set = {"system_prompt"}
-        if immutable_settings is not None:
-            self.blocklist |= set(immutable_settings)
+
+        # Store constructor-supplied immutable settings separately so they
+        # survive config reloads (reload only re-applies config-sourced entries).
+        self._constructor_immutable: set = set(immutable_settings) if immutable_settings is not None else set()
+
+        # Blocklist always includes system_prompt plus constructor-supplied entries.
+        self.blocklist: set = {"system_prompt"} | self._constructor_immutable
 
     @hookimpl
     async def on_init(self, pm, config: dict) -> None:
         await super().on_init(pm, config)
         immutable = config.get("agent", {}).get("immutable_settings", [])
         self.blocklist |= set(immutable)
+
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        """Reset blocklist and re-apply immutable_settings from the new config.
+
+        Resets to constructor-supplied entries plus "system_prompt" first so
+        that removed config entries do not persist across reloads (they would
+        accumulate if we used |= on the existing blocklist).
+        """
+        # Reset to base (constructor entries + system_prompt), then re-apply config.
+        self.blocklist = {"system_prompt"} | self._constructor_immutable
+        immutable = config.get("agent", {}).get("immutable_settings", [])
+        self.blocklist |= set(immutable)
+        logger.debug("on_config_reload: blocklist reset and re-applied")
 
     @hookimpl
     def register_tools(self, tool_registry: list) -> None:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,7 @@ Retry behavior applies to transient status codes (429, 500, 502, 503, 504) and c
 | `daemon.idle_cooldown_seconds` | number | `30` | Minimum seconds between consecutive `on_idle` hook firings. Idle detection is push-based (`Agent._maybe_fire_idle`); this value governs the cooldown between successive firings. |
 | `daemon.sqlite_journal_mode` | string | `wal` | SQLite journal mode for the session database. Allowed values: `delete`, `truncate`, `persist`, `memory`, `wal`, `off`. Read by `PersistencePlugin`. |
 | `daemon.jsonl_log_dir` | string | — | Directory for per-channel JSONL conversation logs. When set, `JsonlLogPlugin` appends one JSON line per conversation event to `<dir>/<channel_id>.jsonl`. Relative paths are resolved against `_base_dir`. Omit to disable JSONL logging. |
+| `daemon.config_poll_interval` | float | `2.0` | Seconds between `agent.yaml` mtime checks by `ConfigWatcherPlugin`. |
 
 ---
 
@@ -218,6 +219,42 @@ mcp:
       tool_prefix: "remote"            # optional; defaults to server name
       timeout_seconds: 30              # optional; default 30
 ```
+
+---
+
+## Hot-reload
+
+`ConfigWatcherPlugin` polls `agent.yaml` for mtime changes every `daemon.config_poll_interval` seconds (default 2.0). When a change is detected, the file is re-parsed, CLI overrides are re-applied, and `on_config_reload` is dispatched to all registered plugins.
+
+No restart is required for the changes listed below. Changes that require restart are listed separately.
+
+### What updates on reload
+
+| Setting | Effect |
+|---------|--------|
+| `llm.main` | New `LLMClient` created and started; old client closed asynchronously after in-flight requests finish. |
+| `agent.compaction_threshold` | `CompactionPlugin` reads the new threshold on its next compaction check. |
+| `agent.chars_per_token` | `Agent` and `CompactionPlugin` use the new ratio for token estimation. |
+| `daemon.idle_cooldown_seconds` | `Agent` uses the new cooldown on the next idle check. |
+| `agent.immutable_settings` | `RuntimeSettingsPlugin` resets its blocklist and re-applies the new list. Constructor-supplied immutable keys are always retained. |
+| New channel entries in `channels:` | `load_channel_config` registers newly added channels. |
+| `agent` defaults | `ChannelRegistry.agent_defaults` is updated; new channels created after the reload use the new defaults. |
+
+### What requires restart
+
+| Setting | Reason |
+|---------|--------|
+| `irc.host`, `irc.port`, `irc.nick` | IRC transport is connected at startup; changing connection parameters requires reconnection. |
+| Existing channel config in `channels:` | Channels already registered retain their original `ChannelConfig` until restart. |
+| `llm.background` | Not updated on reload. |
+| `tools.max_result_chars`, `tools.shell_timeout`, `tools.web_fetch_timeout` | Deferred; not currently implemented in hot-reload path. |
+
+### Error handling
+
+- **Invalid YAML**: logged at `ERROR`; reload is skipped and the running config is unchanged.
+- **Missing `llm.main` after merge**: logged at `ERROR`; reload is skipped.
+- **Config file deleted**: logged at `WARNING`; polling continues. The file may reappear.
+- **Per-plugin failure in `on_config_reload`**: logged at `ERROR`; other plugins still receive the reload.
 
 ---
 

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -124,10 +124,33 @@ The built-in subcommand `scaffold` is registered by corvidae itself under `corvi
 | `on_init(pm, config: dict)` | async broadcast | After all plugins are registered, before `on_start`. Use to store `pm`, read config values, and resolve references to other plugins. Do not create runtime resources here. |
 | `on_start(config: dict)` | async broadcast | Once at startup, after `on_init`. Use to open runtime resources: DB connections, network clients, file handles, asyncio tasks. |
 | `on_stop()` | async broadcast | On SIGINT/SIGTERM, before process exits |
+| `on_config_reload(config: dict)` | async broadcast | When `agent.yaml` is modified while the daemon is running. The config dict has been re-parsed, merged with CLI overrides, and validated before dispatch. |
 
 `config` is the full parsed `agent.yaml` dict. The key `_base_dir` (a `Path`) is set by `Runtime.start()` pointing to the config file's directory.
 
 `CorvidaePlugin.on_init` stores `pm` and `config` as instance attributes. Subclasses that override `on_init` must call `await super().on_init(pm, config)` to preserve this behavior.
+
+#### Supporting hot-reload in plugins
+
+Implement `on_config_reload` to re-read configuration values when `agent.yaml` changes at runtime. The hook fires on the event loop thread; implementations must not block.
+
+```python
+from corvidae.hooks import CorvidaePlugin, hookimpl
+
+class MyPlugin(CorvidaePlugin):
+    @hookimpl
+    async def on_init(self, pm, config: dict) -> None:
+        await super().on_init(pm, config)
+        self.threshold = config.get("my_plugin", {}).get("threshold", 0.8)
+
+    @hookimpl
+    async def on_config_reload(self, config: dict) -> None:
+        self.threshold = config.get("my_plugin", {}).get("threshold", 0.8)
+```
+
+`on_config_reload` receives the full re-parsed config dict, already merged with CLI overrides. Per-plugin errors are caught and logged by `ConfigWatcherPlugin`; a failing `on_config_reload` in one plugin does not prevent other plugins from receiving the reload.
+
+The `config` parameter is optional in `on_config_reload` hookimpls. Pluggy forwards only the arguments declared in the hookimpl signature, so a hookimpl that omits `config` is called with no arguments.
 
 ### Messaging
 
@@ -381,6 +404,7 @@ tools             (ToolCollectionPlugin) — entry point
 dream             (DreamPlugin)         — entry point
 agent             (Agent)               — entry point
 idle_monitor      (IdleMonitorPlugin)   — entry point
+config_watcher    (ConfigWatcherPlugin) — entry point
 ```
 
 `ChannelRegistry` is constructed and registered explicitly before entry points load. Its `agent_defaults` attribute and channel config are populated from config before the `on_init` broadcast runs.
@@ -830,3 +854,31 @@ daemon:
 ```
 
 **Without this plugin:** the `on_idle` hook is never fired. Plugins that implement `on_idle` (such as `DreamPlugin`) will not receive calls.
+
+### ConfigWatcherPlugin (`corvidae/config_watcher.py`)
+
+Polls `agent.yaml` for mtime changes and dispatches `on_config_reload` to all registered plugins when the file changes. Entry point name: `"config_watcher"`.
+
+Implements three hooks:
+
+- `on_init` — reads `_config_path`, `_cli_overrides`, and `daemon.config_poll_interval` from the config dict.
+- `on_start` — records the file's current mtime (to suppress a reload on the first poll) and starts the background polling task.
+- `on_stop` — cancels the polling task and waits for it to finish.
+
+On each poll cycle, when the mtime has changed:
+1. The file is parsed as YAML.
+2. CLI overrides are deep-merged on top of the new YAML.
+3. The result is validated (must be a dict with `llm.main`).
+4. `ChannelRegistry.agent_defaults` is updated from the new `agent` section.
+5. `load_channel_config` is called to register any new channel entries (existing channels are not updated).
+6. `on_config_reload` is dispatched to each plugin individually. A plugin that raises logs an error but does not block the other plugins.
+
+**Config:**
+```yaml
+daemon:
+  config_poll_interval: 2.0   # seconds between mtime checks (default 2.0)
+```
+
+See [Hot-reload](configuration.md#hot-reload) in the configuration reference for which settings update on reload and which require restart.
+
+**Without this plugin:** `agent.yaml` changes are not detected at runtime. Reload requires a daemon restart.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dream = "corvidae.tools.dream:DreamPlugin"
 agent = "corvidae.agent:Agent"
 idle_monitor = "corvidae.idle:IdleMonitorPlugin"
 hot_reload = "corvidae.hot_reload:HotReloadPlugin"
+config_watcher = "corvidae.config_watcher:ConfigWatcherPlugin"
 
 [tool.setuptools.packages.find]
 include = ["corvidae*"]

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -1,0 +1,1056 @@
+"""Tests for config hot-reload (Issue #32).
+
+Coverage:
+    - on_config_reload hookspec on AgentSpec
+    - ConfigWatcherPlugin: importable, file-change detection, YAML reload,
+      hook dispatch, error handling (invalid YAML, missing file),
+      deep_merge with CLI overrides, on_stop task cancellation,
+      _last_mtime initialization (no spurious reload)
+    - Per-plugin error isolation: one failing on_config_reload doesn't block
+      others
+    - LLMPlugin.on_config_reload: new client created, old client closed
+    - CompactionPlugin.on_config_reload: _llm_client cache invalidated
+    - RuntimeSettingsPlugin.on_config_reload: blocklist reset then re-applied
+    - Agent.on_config_reload: system_prompt unchanged, chars_per_token updated
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# 1. on_config_reload hookspec exists on AgentSpec
+# ---------------------------------------------------------------------------
+
+
+def test_on_config_reload_hookspec_exists():
+    """AgentSpec must define an on_config_reload hookspec."""
+    from corvidae.hooks import AgentSpec
+
+    assert hasattr(AgentSpec, "on_config_reload"), (
+        "AgentSpec must have an on_config_reload hookspec"
+    )
+
+
+def test_on_config_reload_is_callable():
+    """on_config_reload on AgentSpec must be callable."""
+    from corvidae.hooks import AgentSpec
+
+    assert callable(AgentSpec.on_config_reload)
+
+
+def test_on_config_reload_hookspec_registered_in_pm():
+    """create_plugin_manager() must include on_config_reload in the hook list."""
+    from corvidae.hooks import create_plugin_manager
+
+    pm = create_plugin_manager()
+    hook = pm.hook.on_config_reload
+    assert hook is not None, "on_config_reload must be a registered hook in the plugin manager"
+
+
+# ---------------------------------------------------------------------------
+# 2. ConfigWatcherPlugin is importable and has expected interface
+# ---------------------------------------------------------------------------
+
+
+def test_config_watcher_plugin_importable():
+    """corvidae.config_watcher.ConfigWatcherPlugin must be importable."""
+    from corvidae.config_watcher import ConfigWatcherPlugin  # noqa: F401
+
+
+def test_config_watcher_plugin_has_on_start():
+    """ConfigWatcherPlugin must have an on_start hookimpl."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    assert hasattr(ConfigWatcherPlugin, "on_start"), (
+        "ConfigWatcherPlugin must have an on_start method"
+    )
+
+
+def test_config_watcher_plugin_has_on_stop():
+    """ConfigWatcherPlugin must have an on_stop hookimpl."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    assert hasattr(ConfigWatcherPlugin, "on_stop"), (
+        "ConfigWatcherPlugin must have an on_stop method"
+    )
+
+
+def test_config_watcher_plugin_has_on_init():
+    """ConfigWatcherPlugin must have an on_init hookimpl."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    assert hasattr(ConfigWatcherPlugin, "on_init"), (
+        "ConfigWatcherPlugin must have an on_init method"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2b. ConfigWatcherPlugin reads configurable poll interval from config
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_reads_poll_interval_from_config(tmp_path):
+    """ConfigWatcherPlugin.on_init must read daemon.config_poll_interval from config
+    and store it as self._poll_interval.
+
+    If the key is absent, a sensible default (e.g. 1.0 second) must be used.
+    """
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "daemon": {"config_poll_interval": 5.0},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    assert hasattr(plugin, "_poll_interval"), (
+        "ConfigWatcherPlugin must have a _poll_interval attribute after on_init"
+    )
+    assert plugin._poll_interval == 5.0, (
+        f"ConfigWatcherPlugin must read _poll_interval from daemon.config_poll_interval. "
+        f"Got {plugin._poll_interval!r}"
+    )
+
+
+async def test_config_watcher_poll_interval_default(tmp_path):
+    """ConfigWatcherPlugin._poll_interval must have a sensible default when
+    daemon.config_poll_interval is absent from config.
+    """
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    assert hasattr(plugin, "_poll_interval"), (
+        "ConfigWatcherPlugin must have a _poll_interval attribute after on_init"
+    )
+    assert isinstance(plugin._poll_interval, (int, float)), (
+        "_poll_interval must be numeric"
+    )
+    assert plugin._poll_interval > 0, (
+        "_poll_interval default must be a positive number"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. ConfigWatcherPlugin detects file changes (mtime change triggers reload)
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_detects_mtime_change(tmp_path):
+    """ConfigWatcherPlugin must call _reload_config when file mtime changes."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Patch _reload_config to track calls
+    reload_calls = []
+
+    async def fake_reload():
+        reload_calls.append(True)
+
+    plugin._reload_config = fake_reload
+
+    # Set _last_mtime to a value older than actual file mtime to trigger reload
+    plugin._last_mtime = 0.0
+
+    # Run _watch_loop for one iteration: return False on first call (enter loop),
+    # True on subsequent calls (exit loop after one pass).
+    call_count = 0
+
+    def side_effect():
+        nonlocal call_count
+        call_count += 1
+        return call_count > 1
+
+    plugin._stop_event = MagicMock()
+    plugin._stop_event.is_set.side_effect = side_effect
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await plugin._watch_loop()
+
+    assert reload_calls, "ConfigWatcherPlugin must call _reload_config when mtime changes"
+
+
+# ---------------------------------------------------------------------------
+# 4. ConfigWatcherPlugin does NOT reload on start (no spurious reload)
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_no_spurious_reload_on_start(tmp_path):
+    """on_start must initialize _last_mtime from actual file mtime to avoid
+    a reload on the first poll cycle (M1 from design review)."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    actual_mtime = config_file.stat().st_mtime
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    reload_calls = []
+
+    async def fake_reload():
+        reload_calls.append(True)
+
+    plugin._reload_config = fake_reload
+
+    # on_start must set _last_mtime to actual file mtime
+    with patch.object(plugin, "_watch_loop", new_callable=AsyncMock):
+        await plugin.on_start(config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        })
+
+    assert plugin._last_mtime == actual_mtime, (
+        f"on_start must initialize _last_mtime to file's actual mtime ({actual_mtime}), "
+        f"got {plugin._last_mtime}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. ConfigWatcherPlugin reloads and parses YAML on change
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_reloads_yaml_on_change(tmp_path):
+    """_reload_config must read and parse the YAML file when mtime changes."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m1\n")
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = []
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m1"}},
+        },
+    )
+
+    # Write new YAML content
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m2\n")
+
+    # Patch _dispatch_config_reload to capture what config it receives
+    dispatched_configs = []
+
+    async def capture_dispatch(config: dict) -> None:
+        dispatched_configs.append(config)
+
+    plugin._dispatch_config_reload = capture_dispatch
+
+    await plugin._reload_config()
+
+    assert dispatched_configs, "_reload_config must dispatch to plugins"
+    assert dispatched_configs[0].get("llm", {}).get("main", {}).get("model") == "m2", (
+        "Reloaded config must contain updated YAML values"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. ConfigWatcherPlugin applies deep_merge with CLI overrides on reload
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_applies_cli_overrides_on_reload(tmp_path):
+    """_reload_config must deep_merge CLI overrides on top of new YAML."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: from-yaml\n")
+
+    cli_overrides = {"llm": {"main": {"model": "from-cli"}}}
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = []
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": cli_overrides,
+            "llm": {"main": {"base_url": "http://localhost", "model": "from-cli"}},
+        },
+    )
+
+    dispatched_configs = []
+
+    async def capture_dispatch(config: dict) -> None:
+        dispatched_configs.append(config)
+
+    plugin._dispatch_config_reload = capture_dispatch
+
+    await plugin._reload_config()
+
+    assert dispatched_configs, "_reload_config must dispatch"
+    merged_model = dispatched_configs[0].get("llm", {}).get("main", {}).get("model")
+    assert merged_model == "from-cli", (
+        f"CLI overrides must win over YAML content after merge. Got model={merged_model!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6b. ConfigWatcherPlugin updates ChannelRegistry.agent_defaults on reload
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_updates_channel_registry_agent_defaults(tmp_path):
+    """_reload_config must update ChannelRegistry.agent_defaults from the new config.
+
+    The design specifies: ChannelRegistry.agent_defaults = new_config.get("agent", {})
+    This update is performed directly in ConfigWatcherPlugin._reload_config, not
+    via a per-plugin hookimpl.
+    """
+    from corvidae.config_watcher import ConfigWatcherPlugin
+    from corvidae.channel import ChannelRegistry
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text(
+        "agent:\n  max_turns: 5\nllm:\n  main:\n    base_url: http://localhost\n    model: m\n"
+    )
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = []
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "agent": {"max_turns": 5},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Write updated YAML with new agent defaults
+    config_file.write_text(
+        "agent:\n  max_turns: 20\nllm:\n  main:\n    base_url: http://localhost\n    model: m\n"
+    )
+
+    async def no_op_dispatch(config: dict) -> None:
+        pass
+
+    plugin._dispatch_config_reload = no_op_dispatch
+
+    original = ChannelRegistry.agent_defaults
+    try:
+        await plugin._reload_config()
+
+        assert ChannelRegistry.agent_defaults.get("max_turns") == 20, (
+            "_reload_config must update ChannelRegistry.agent_defaults with the new agent config"
+        )
+    finally:
+        ChannelRegistry.agent_defaults = original
+
+
+# ---------------------------------------------------------------------------
+# 7. ConfigWatcherPlugin handles invalid YAML gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_handles_invalid_yaml(tmp_path, caplog):
+    """_reload_config must log an error and not crash on invalid YAML."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = []
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Write invalid YAML
+    config_file.write_text(": invalid: yaml: [unclosed")
+
+    dispatched = []
+
+    async def capture_dispatch(config: dict) -> None:
+        dispatched.append(config)
+
+    plugin._dispatch_config_reload = capture_dispatch
+
+    with caplog.at_level(logging.ERROR, logger="corvidae.config_watcher"):
+        # Must not raise
+        await plugin._reload_config()
+
+    assert not dispatched, "Invalid YAML must not result in a dispatch"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "Invalid YAML must produce an ERROR log"
+
+
+# ---------------------------------------------------------------------------
+# 8. ConfigWatcherPlugin handles missing file gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_handles_missing_file(tmp_path, caplog):
+    """_watch_loop must log a warning and continue when the config file is missing."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    # File does not exist
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+        },
+    )
+
+    plugin._last_mtime = 0.0
+
+    # Return False on first call (enter loop body), True on subsequent calls (exit).
+    call_count = 0
+
+    def side_effect():
+        nonlocal call_count
+        call_count += 1
+        return call_count > 1
+
+    plugin._stop_event = MagicMock()
+    plugin._stop_event.is_set.side_effect = side_effect
+
+    with caplog.at_level(logging.WARNING, logger="corvidae.config_watcher"):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            # Must not raise even though the file is missing
+            await plugin._watch_loop()
+
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records, "Missing config file must produce a WARNING log"
+
+
+# ---------------------------------------------------------------------------
+# 9. ConfigWatcherPlugin validates config (rejects if llm.main absent)
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_rejects_config_without_llm_main(tmp_path, caplog):
+    """_reload_config must skip dispatch when llm.main is absent after merge."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    # YAML without llm.main
+    config_file.write_text("agent:\n  max_turns: 10\n")
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = []
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            # Original config had llm.main
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    dispatched = []
+
+    async def capture_dispatch(config: dict) -> None:
+        dispatched.append(config)
+
+    plugin._dispatch_config_reload = capture_dispatch
+
+    with caplog.at_level(logging.ERROR, logger="corvidae.config_watcher"):
+        await plugin._reload_config()
+
+    assert not dispatched, "Config without llm.main must not be dispatched"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "Missing llm.main must produce an ERROR log"
+
+
+# ---------------------------------------------------------------------------
+# 10. ConfigWatcherPlugin.on_stop cancels the watcher task
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_on_stop_cancels_task(tmp_path):
+    """on_stop must cancel the watcher task started by on_start."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Simulate on_start by creating a real asyncio task that blocks
+    async def infinite_loop():
+        try:
+            while True:
+                await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            raise
+
+    plugin._watcher_task = asyncio.create_task(infinite_loop())
+    plugin._stop_event = asyncio.Event()
+
+    # on_stop must cancel the task and not hang
+    await plugin.on_stop()
+
+    assert plugin._watcher_task is None or plugin._watcher_task.cancelled() or plugin._watcher_task.done(), (
+        "on_stop must cancel the watcher task"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. Per-plugin error isolation: one failing plugin doesn't block others
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_per_plugin_error_isolation(tmp_path, caplog):
+    """_dispatch_config_reload must call each plugin independently.
+    A plugin that raises must not prevent other plugins from receiving the config.
+    """
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    # Create two mock hookimpls: first raises, second succeeds
+    received_configs = []
+
+    async def failing_impl(config: dict) -> None:
+        raise RuntimeError("intentional failure in on_config_reload")
+
+    async def succeeding_impl(config: dict) -> None:
+        received_configs.append(config)
+
+    hookimpl_failing = MagicMock()
+    hookimpl_failing.function = failing_impl
+    hookimpl_failing.argnames = ["config"]
+    hookimpl_failing.plugin_name = "failing_plugin"
+
+    hookimpl_succeeding = MagicMock()
+    hookimpl_succeeding.function = succeeding_impl
+    hookimpl_succeeding.argnames = ["config"]
+    hookimpl_succeeding.plugin_name = "succeeding_plugin"
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = [
+        hookimpl_failing,
+        hookimpl_succeeding,
+    ]
+
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    test_config = {"llm": {"main": {"base_url": "http://localhost", "model": "m"}}}
+
+    with caplog.at_level(logging.ERROR, logger="corvidae.config_watcher"):
+        await plugin._dispatch_config_reload(test_config)
+
+    assert received_configs, (
+        "succeeding plugin must receive config even though failing plugin raised"
+    )
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "Failing plugin must produce an ERROR log"
+
+
+# ---------------------------------------------------------------------------
+# 12. _dispatch_config_reload filters kwargs by argnames
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_config_reload_filters_kwargs_by_argnames(tmp_path):
+    """_dispatch_config_reload must filter kwargs by hook_impl.argnames.
+    Hookimpls that omit 'config' from their signature must receive no arguments
+    rather than raising TypeError (NEW-I1 from design review Fix #2).
+    """
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    called = []
+
+    async def impl_no_config_arg() -> None:
+        # This impl deliberately has no 'config' param
+        called.append(True)
+
+    hookimpl_no_config = MagicMock()
+    hookimpl_no_config.function = impl_no_config_arg
+    hookimpl_no_config.argnames = []  # no 'config' in argnames
+    hookimpl_no_config.plugin_name = "no_config_plugin"
+
+    pm = MagicMock()
+    pm.hook.on_config_reload.get_hookimpls.return_value = [hookimpl_no_config]
+
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Must not raise TypeError
+    await plugin._dispatch_config_reload(
+        {"llm": {"main": {"base_url": "http://localhost", "model": "m"}}}
+    )
+
+    assert called, "Plugin with no 'config' arg must still be called"
+
+
+# ---------------------------------------------------------------------------
+# 13. LLMPlugin.on_config_reload creates new client when llm config changes
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_plugin_on_config_reload_creates_new_client_on_change():
+    """LLMPlugin.on_config_reload must create a new main_client when llm.main changes."""
+    from corvidae.llm_plugin import LLMPlugin
+
+    plugin = LLMPlugin(pm=None)
+    await plugin.on_init(
+        pm=None,
+        config={"llm": {"main": {"base_url": "http://old", "model": "old-model"}}},
+    )
+
+    old_client = MagicMock(name="old_client")
+    old_client.start = AsyncMock()
+    old_client.stop = AsyncMock()
+    plugin.main_client = old_client
+
+    new_client = MagicMock(name="new_client")
+    new_client.start = AsyncMock()
+
+    new_config = {"llm": {"main": {"base_url": "http://new", "model": "new-model"}}}
+
+    with patch.object(LLMPlugin, "_create_client", return_value=new_client):
+        await plugin.on_config_reload(config=new_config)
+
+    assert plugin.main_client is new_client, (
+        "on_config_reload must swap main_client to the new client"
+    )
+    new_client.start.assert_awaited_once()
+
+
+async def test_llm_plugin_on_config_reload_schedules_old_client_close():
+    """LLMPlugin.on_config_reload must schedule closure of the old client
+    via asyncio.create_task (to allow in-flight requests to finish)."""
+    from corvidae.llm_plugin import LLMPlugin
+
+    plugin = LLMPlugin(pm=None)
+    await plugin.on_init(
+        pm=None,
+        config={"llm": {"main": {"base_url": "http://old", "model": "old-model"}}},
+    )
+
+    old_client = MagicMock(name="old_client")
+    old_client.start = AsyncMock()
+    old_client.stop = AsyncMock()
+    plugin.main_client = old_client
+
+    new_client = MagicMock(name="new_client")
+    new_client.start = AsyncMock()
+
+    new_config = {"llm": {"main": {"base_url": "http://new", "model": "new-model"}}}
+
+    tasks_created = []
+    original_create_task = asyncio.create_task
+
+    def tracking_create_task(coro, **kwargs):
+        task = original_create_task(coro, **kwargs)
+        tasks_created.append(task)
+        return task
+
+    with patch.object(LLMPlugin, "_create_client", return_value=new_client):
+        with patch("asyncio.create_task", side_effect=tracking_create_task):
+            await plugin.on_config_reload(config=new_config)
+
+    assert tasks_created, (
+        "on_config_reload must schedule old client closure via asyncio.create_task"
+    )
+
+
+async def test_llm_plugin_on_config_reload_no_change_no_swap():
+    """LLMPlugin.on_config_reload must NOT create a new client when llm.main is unchanged."""
+    from corvidae.llm_plugin import LLMPlugin
+
+    same_config = {"llm": {"main": {"base_url": "http://localhost", "model": "m"}}}
+    plugin = LLMPlugin(pm=None)
+    await plugin.on_init(pm=None, config=same_config)
+
+    original_client = MagicMock(name="original_client")
+    original_client.start = AsyncMock()
+    plugin.main_client = original_client
+
+    create_calls = []
+    original_create = LLMPlugin._create_client
+
+    # Use module-level patch to avoid staticmethod binding issue where
+    # patch.object would pass `self` as the first argument.
+    with patch("corvidae.llm_plugin.LLMPlugin._create_client", side_effect=lambda cfg: (create_calls.append(cfg), original_create(cfg))[1]):
+        await plugin.on_config_reload(config=same_config)
+
+    assert not create_calls, (
+        "on_config_reload must not create a new client when llm.main config is unchanged"
+    )
+    assert plugin.main_client is original_client
+
+
+# ---------------------------------------------------------------------------
+# 14. CompactionPlugin.on_config_reload invalidates _llm_client cache
+# ---------------------------------------------------------------------------
+
+
+async def test_compaction_plugin_on_config_reload_invalidates_llm_client():
+    """CompactionPlugin.on_config_reload must set _llm_client = None
+    so it is re-resolved from LLMPlugin on next use (I1 from design review Fix #1)."""
+    from corvidae.compaction import CompactionPlugin
+
+    plugin = CompactionPlugin(pm=None)
+    await plugin.on_init(
+        pm=None,
+        config={"agent": {}, "llm": {"main": {"base_url": "http://localhost", "model": "m"}}},
+    )
+
+    # Simulate a cached LLM client
+    plugin._llm_client = MagicMock(name="stale_client")
+
+    new_config = {
+        "agent": {"compaction_threshold": 0.9},
+        "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+    }
+    await plugin.on_config_reload(config=new_config)
+
+    assert plugin._llm_client is None, (
+        "CompactionPlugin.on_config_reload must reset _llm_client to None"
+    )
+
+
+async def test_compaction_plugin_on_config_reload_updates_threshold():
+    """CompactionPlugin.on_config_reload must re-read compaction_threshold from config."""
+    from corvidae.compaction import CompactionPlugin
+
+    plugin = CompactionPlugin(pm=None)
+    await plugin.on_init(
+        pm=None,
+        config={"agent": {"compaction_threshold": 0.8}, "llm": {"main": {"base_url": "http://localhost", "model": "m"}}},
+    )
+
+    assert plugin._compaction_threshold == 0.8
+
+    await plugin.on_config_reload(config={
+        "agent": {"compaction_threshold": 0.9},
+        "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+    })
+
+    assert plugin._compaction_threshold == 0.9, (
+        "CompactionPlugin.on_config_reload must update _compaction_threshold"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 15. RuntimeSettingsPlugin.on_config_reload resets and re-applies blocklist
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_settings_plugin_on_config_reload_resets_blocklist():
+    """RuntimeSettingsPlugin.on_config_reload must reset blocklist to
+    _constructor_immutable | {'system_prompt'} before re-applying config.
+    Removed entries must not persist (I3 from design review Fix #1)."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+
+    plugin = RuntimeSettingsPlugin(pm=None, immutable_settings={"constructor_key"})
+    await plugin.on_init(
+        pm=None,
+        config={"agent": {"immutable_settings": ["config_key"]}},
+    )
+
+    # Both constructor_key and config_key should be in blocklist
+    assert "constructor_key" in plugin.blocklist
+    assert "config_key" in plugin.blocklist
+
+    # Reload with config that no longer has config_key
+    await plugin.on_config_reload(config={"agent": {"immutable_settings": []}})
+
+    # config_key must be removed; constructor_key and system_prompt must remain
+    assert "config_key" not in plugin.blocklist, (
+        "config_key must be removed from blocklist when removed from config on reload"
+    )
+    assert "constructor_key" in plugin.blocklist, (
+        "constructor_key must remain (was provided in constructor)"
+    )
+    assert "system_prompt" in plugin.blocklist, (
+        "system_prompt must always remain in blocklist"
+    )
+
+
+async def test_runtime_settings_plugin_stores_constructor_immutable():
+    """RuntimeSettingsPlugin must store constructor-supplied immutable_settings
+    separately in _constructor_immutable so they survive reloads (NEW-M1)."""
+    from corvidae.tools.settings import RuntimeSettingsPlugin
+
+    plugin = RuntimeSettingsPlugin(pm=None, immutable_settings={"ctor_key"})
+
+    assert hasattr(plugin, "_constructor_immutable"), (
+        "RuntimeSettingsPlugin must have a _constructor_immutable attribute"
+    )
+    assert "ctor_key" in plugin._constructor_immutable, (
+        "_constructor_immutable must contain keys passed to the constructor"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 16. Agent.on_config_reload updates chars_per_token
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_on_config_reload_updates_chars_per_token():
+    """Agent.on_config_reload must re-read chars_per_token from the new config."""
+    from corvidae.agent import Agent
+
+    pm = MagicMock()
+    plugin = Agent(pm=pm)
+    await plugin.on_init(
+        pm=pm,
+        config={"agent": {"chars_per_token": 4.0}},
+    )
+
+    assert plugin._chars_per_token == 4.0
+
+    await plugin.on_config_reload(config={"agent": {"chars_per_token": 5.0}})
+
+    assert plugin._chars_per_token == 5.0, (
+        "Agent.on_config_reload must update _chars_per_token"
+    )
+
+
+async def test_agent_on_config_reload_reborrow_llm_client():
+    """Agent.on_config_reload must re-borrow _client from LLMPlugin after
+    LLMPlugin may have swapped its client (correction in design Key Decision #3)."""
+    from corvidae.agent import Agent
+    from corvidae.llm_plugin import LLMPlugin
+
+    pm = MagicMock()
+    plugin = Agent(pm=pm)
+
+    # Set up a mock LLMPlugin reachable from pm
+    mock_llm_plugin = MagicMock(spec=LLMPlugin)
+    new_mock_client = MagicMock(name="new_llm_client")
+    mock_llm_plugin.get_client.return_value = new_mock_client
+    pm.get_plugin.return_value = mock_llm_plugin
+
+    old_client = MagicMock(name="old_llm_client")
+    plugin._client = old_client
+
+    await plugin.on_config_reload(config={"agent": {}, "llm": {"main": {"base_url": "http://localhost", "model": "m"}}})
+
+    assert plugin._client is new_mock_client, (
+        "Agent.on_config_reload must re-borrow _client from LLMPlugin"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 17. ConfigWatcherPlugin reads _config_path and _cli_overrides from config
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_reads_config_path_from_reserved_key(tmp_path):
+    """ConfigWatcherPlugin.on_init must read _config_path from config dict
+    (I4 from design review Fix #1 — consistent with _base_dir pattern)."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {"llm": {"main": {"api_key": "override-key"}}},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    assert plugin._config_path == config_file, (
+        "ConfigWatcherPlugin must store _config_path from config dict"
+    )
+    assert plugin._cli_overrides == {"llm": {"main": {"api_key": "override-key"}}}, (
+        "ConfigWatcherPlugin must store _cli_overrides from config dict"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 18. ConfigWatcherPlugin handles FileNotFoundError on on_start gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_on_start_handles_missing_file(tmp_path):
+    """on_start must set _last_mtime to 0.0 when the config file is missing
+    (FileNotFoundError fallback from design doc on_start code)."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "nonexistent.yaml"
+    # File does not exist
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={"_config_path": config_file, "_cli_overrides": {}},
+    )
+
+    with patch.object(plugin, "_watch_loop", new_callable=AsyncMock):
+        await plugin.on_start(config={"_config_path": config_file, "_cli_overrides": {}})
+
+    assert plugin._last_mtime == 0.0, (
+        "on_start must set _last_mtime to 0.0 when config file does not exist"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 19. ConfigWatcherPlugin on_start creates _watcher_task
+# ---------------------------------------------------------------------------
+
+
+async def test_config_watcher_on_start_creates_watcher_task(tmp_path):
+    """on_start must create an asyncio.Task for the polling loop."""
+    from corvidae.config_watcher import ConfigWatcherPlugin
+
+    config_file = tmp_path / "agent.yaml"
+    config_file.write_text("llm:\n  main:\n    base_url: http://localhost\n    model: m\n")
+
+    pm = MagicMock()
+    plugin = ConfigWatcherPlugin()
+    await plugin.on_init(
+        pm=pm,
+        config={
+            "_config_path": config_file,
+            "_cli_overrides": {},
+            "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+        },
+    )
+
+    # Patch _watch_loop so the task doesn't actually run the real loop
+    loop_started = []
+
+    async def fake_loop():
+        loop_started.append(True)
+        # Yield control to allow the task to be inspected, then return
+        await asyncio.sleep(0)
+
+    plugin._watch_loop = fake_loop
+
+    await plugin.on_start(config={
+        "_config_path": config_file,
+        "_cli_overrides": {},
+        "llm": {"main": {"base_url": "http://localhost", "model": "m"}},
+    })
+
+    assert plugin._watcher_task is not None, (
+        "on_start must create a _watcher_task"
+    )
+    assert isinstance(plugin._watcher_task, asyncio.Task), (
+        "_watcher_task must be an asyncio.Task"
+    )
+
+    # Clean up
+    plugin._watcher_task.cancel()
+    try:
+        await plugin._watcher_task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 20. HotReloadPlugin.on_config_reload updates self.config
+# ---------------------------------------------------------------------------
+
+
+async def test_hot_reload_plugin_on_config_reload_updates_config():
+    """HotReloadPlugin.on_config_reload must update self.config for newly loaded plugins."""
+    from corvidae.hot_reload import HotReloadPlugin
+    plugin = HotReloadPlugin()
+    plugin.config = {"old": "config"}
+    new_config = {"new": "config", "llm": {"main": {"model": "test"}}}
+    await plugin.on_config_reload(config=new_config)
+    assert plugin.config == new_config


### PR DESCRIPTION
## Summary

- Adds `ConfigWatcherPlugin` that polls `agent.yaml` for mtime changes and dispatches a new `on_config_reload` hook to all registered plugins
- Core plugins (`LLMPlugin`, `Agent`, `CompactionPlugin`, `RuntimeSettingsPlugin`, `HotReloadPlugin`) implement `on_config_reload` to pick up config changes at runtime
- `LLMPlugin` swaps the main LLM client when `llm.main` changes, with deferred closure of the old client to allow in-flight requests to complete
- Documentation added to `configuration.md` (hot-reload reference) and `plugin-guide.md` (how to support hot-reload in plugins)

Closes #32

## Test plan

- [ ] Run `tests/test_config_watcher.py` to verify polling, reload dispatch, and error handling
- [ ] Verify existing test suite passes with no regressions
- [ ] Manual test: start daemon, edit `agent.yaml`, confirm config changes take effect without restart