### PR TITLE
Scaffold agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,17 @@
 
 * If you are solving a GitHub issue, post the requirements and implementation plan as a comment on the issue before implementing.
 * Check @docs/ before your work is complete and make sure the documentation is updated.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (schuyler/corvidae). Uses the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Uses the default five-label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -63,6 +63,11 @@ responsibility.
 
 ### Three-layer stage exit
 
+Within a stage, the LLM runs in a tool-calling loop (like Corvidae's
+`run_agent_loop`). It may call tools multiple times — write files, run
+shell commands, post comments — before signalling completion. The loop
+ends when the LLM calls the `stage_complete` tool.
+
 A stage completes when:
 
 1. The LLM calls a structured `stage_complete(outcome, summary)` tool

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,164 @@
+# Semi-Deterministic Workflow Engine
+
+A Python orchestrator that drives an LLM through a multi-stage workflow,
+with deterministic control flow and focused LLM invocations at each stage.
+
+This directory contains an in-repo prototype. It will likely be extracted
+into its own package once the design stabilises.
+
+## Why This Exists
+
+Giving an LLM a complete multi-stage workflow in a single prompt fails in
+practice. As context grows, the model skips stages, forgets instructions,
+and drifts from the intended process. The workflow engine solves this by
+keeping the LLM's job small and focused:
+
+- **Deterministic code** controls the workflow — which stage runs, in what
+  order, and when to loop back.
+- **The LLM** does what it's good at — reasoning, writing, deciding — within
+  a single stage at a time, with a focused prompt and limited tool set.
+
+## Core Principles
+
+### Stage isolation
+
+Each LLM invocation starts fresh. No accumulated conversation history from
+previous stages. The LLM receives only what it needs for the current stage:
+a system prompt, the stage instruction, and concise context from prior
+stages.
+
+This prevents context drift and means each stage is predictable and
+testable in isolation.
+
+### The orchestrator gathers facts; the LLM explains reasoning
+
+Stage output has two channels:
+
+1. **LLM summary** — decisions made, reasoning behind them, approaches
+   tried and rejected. Only things that require *judgment*.
+2. **Orchestrator-gathered facts** — file diffs, test results, branch
+   names, GitHub state. Anything observable programmatically.
+
+The LLM never redundantly reports what the orchestrator can verify
+directly. This keeps summaries small and prevents inaccurate
+second-hand reporting of facts.
+
+### Linear backbone with escape hatches
+
+Workflows proceed forward through a defined sequence of stages. Specific
+stages may "escape" backward to an earlier point when conditions warrant
+(e.g., implementation reveals scope ambiguity → back to issue commenting
+to ask questions).
+
+This is not a general state machine. Every stage has a default forward
+path, and only explicitly defined escape targets are allowed.
+
+### Tool scoping per stage
+
+Each stage only receives the tools it needs. The implementation stage gets
+shell and file tools; the PR stage gets GitHub API tools; the "comment on
+issue" stage gets GitHub comment tools. This reduces the LLM's decision
+space and prevents it from taking actions outside its current
+responsibility.
+
+### Three-layer stage exit
+
+A stage completes when:
+
+1. The LLM calls a structured `stage_complete(outcome, summary)` tool
+2. The orchestrator independently verifies the stage's exit criteria
+   (tests exist, comment was posted, files changed, etc.)
+3. If configured, a human approves before proceeding
+
+All three must pass. If exit criteria fail, the orchestrator tells the
+LLM what's missing and lets it retry within the same stage invocation.
+
+### Structured outcomes
+
+The LLM signals completion with an explicit outcome:
+
+- `proceed` — stage is done, move to the next one
+- `need_clarification` — loop back to an earlier stage (escape hatch)
+- `scope_changed` — the task is different than expected; may loop back
+- `blocked` — something unexpected prevents progress; needs human input
+
+The orchestrator maps outcomes to transitions (including escape targets)
+using the workflow definition. The LLM never chooses the next stage
+directly.
+
+## Relationship to Corvidae
+
+The workflow engine is a separate program that uses Corvidae as an LLM
+invocation layer. It imports Corvidae's primitives directly:
+
+- `run_agent_turn` — single LLM invocation with tool calling
+- `LLMClient` — HTTP client for the LLM API
+- `ToolRegistry` / `Tool` — tool definitions and schema generation
+
+The engine reads `agent.yaml` for LLM configuration (model, base URL,
+API key) so there's a single config file for both systems.
+
+This "thin client" approach (Approach A) is the starting point. As
+patterns emerge, the engine may evolve into a declarative framework
+(Approach B) or a Corvidae plugin (Approach C).
+
+## Example Workflow: GitHub Issue Implementation
+
+The motivating workflow. Stages:
+
+1. **Comment on issue** — LLM writes a comment describing its
+   implementation plan. *Tools: GitHub comments API.*
+2. **Add "in progress" label** — Mechanical. No LLM.
+3. **Create branch and worktree** — Mostly mechanical. LLM may suggest
+   a branch name. *Tools: git.*
+4. **Gate: ready to implement?** — LLM decides whether it has enough
+   information, or needs to go back and ask more questions in the issue.
+   *Escape target: stage 1.*
+5. **Write tests (red)** — LLM writes failing tests. *Tools: file write,
+   shell.*
+6. **Implement (green)** — LLM writes code to pass the tests. *Tools:
+   file write, shell, file read.*
+7. **Refactor** — LLM cleans up. *Tools: file write, shell, file read.*
+8. **Gate: docs needed?** — LLM decides whether documentation updates
+   would add value.
+9. **Update docs** — LLM writes documentation. *Tools: file write.*
+10. **Submit PR** — LLM writes PR description. Mechanical PR creation.
+    *Tools: GitHub PR API.*
+11. **Respond to PR feedback** — LLM reads review comments and makes
+    changes. May loop. *Tools: file write, shell, GitHub API.*
+    *Escape target: stage 7 (refactor) or stage 5 (rewrite tests).*
+12. **Close issue** — Mechanical. Post a comment linking to the merged PR.
+
+Human gates are configurable per stage. Likely candidates: before stage 5
+(ready to implement?), before stage 10 (ready to submit PR?).
+
+## Evolution Path
+
+1. **Now** — Standalone Python script importing Corvidae primitives.
+    One workflow (GitHub issue implementation), defined in code.
+2. **Near future** — Extract reusable stage machinery: prompt building,
+    tool scoping, exit verification, summary accumulation. Still one
+    workflow, but the orchestration pattern is a clean abstraction.
+3. **When needed** — Declarative workflow definitions (Python decorators
+    or YAML) so new workflows can be defined without writing orchestration
+    code. Multiple workflows (issue implementation, code review, bug
+    triage, release preparation).
+4. **If needed** — Corvidae plugin integration, so workflows can be
+    triggered from any channel (IRC message, CLI command, webhook).
+
+## Key Decisions for Future Agents
+
+- **Never give the LLM the full workflow.** It sees one stage at a time.
+  The orchestrator is the authority on what happens next.
+- **Never let the LLM choose the next stage.** It signals an outcome;
+  the orchestrator maps it to a transition.
+- **Keep summaries about reasoning, not facts.** File diffs, test
+  results, and GitHub state come from the orchestrator. The LLM explains
+  *why*, not *what*.
+- **Include rejected approaches in summaries.** Future stages and human
+  reviewers benefit from knowing what was tried and abandoned.
+- **Verify independently.** Don't trust the LLM's claim that it's done.
+  Check exit criteria programmatically.
+- **Start thin, evolve when patterns are clear.** Don't build a
+  framework until you've built at least two workflows and can see what's
+  reusable.

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -30,14 +30,21 @@ stages.
 This prevents context drift and means each stage is predictable and
 testable in isolation.
 
-### The orchestrator gathers facts; the LLM explains reasoning
+### Prefer deterministic code; the LLM explains reasoning
+
+Where possible, move responsibility for any work to deterministic code
+rather than the LLM. The LLM should only do things that require
+judgment. If it's unclear whether a task needs the LLM, prefer
+deterministic code and check with a human when output quality might
+suffer.
 
 Stage output has two channels:
 
 1. **LLM summary** — decisions made, reasoning behind them, approaches
    tried and rejected. Only things that require *judgment*.
 2. **Orchestrator-gathered facts** — file diffs, test results, branch
-   names, GitHub state. Anything observable programmatically.
+   names, GitHub state, and the inputs and outputs of tool calls made
+   during the stage. Anything observable programmatically.
 
 The LLM never redundantly reports what the orchestrator can verify
 directly. This keeps summaries small and prevents inaccurate
@@ -164,6 +171,13 @@ Human gates are configurable per stage. Likely candidates: before stage 5
   reviewers benefit from knowing what was tried and abandoned.
 - **Verify independently.** Don't trust the LLM's claim that it's done.
   Check exit criteria programmatically.
+- **Prefer deterministic code.** If a task can be done without the LLM,
+  do it in code. If it's unclear, prefer code and ask a human when output
+  quality might suffer. The LLM is expensive and unreliable; Python is
+  cheap and deterministic.
+- **Capture tool I/O.** The orchestrator logs tool call inputs and
+  outputs as facts. The LLM doesn't need to summarise what it did — the
+  orchestrator already knows.
 - **Start thin, evolve when patterns are clear.** Don't build a
   framework until you've built at least two workflows and can see what's
   reusable.


### PR DESCRIPTION
Adds per-repo configuration for Matt Pocock's engineering skills.

## Changes

- **AGENTS.md**: Added `## Agent skills` section pointing to config docs
- **docs/agents/issue-tracker.md**: GitHub Issues via `gh` CLI
- **docs/agents/triage-labels.md**: Default five-label triage vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix)
- **docs/agents/domain.md**: Single-context layout consumer rules for CONTEXT.md + docs/adr/

These files tell skills like `triage`, `to-issues`, `to-prd`, `tdd`, `diagnose`, and `improve-codebase-architecture` where to find things and what conventions to follow.