### PR TITLE
chore: non-workflow improvements from PR #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ uv.lock
 # local dev
 apluggy
 *.log
+
+# artifacts
+.superpowers/
+eval_results.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Corvidae is a minimalist, extensible architecture for building LLM agent harness
 
 Three layers: a plugin system ([apluggy](https://github.com/nextline-dev/apluggy)), an agent loop, and transport plugins. Each transport converts platform-specific messages to a common Channel abstraction. The agent loop handles prompt construction and LLM interaction. The plugin system wires everything together via lifecycle hooks.
 
-Every built-in plugin is optional. Without PersistencePlugin, messages drop but the daemon doesn't crash. Without CompactionPlugin, history grows unbounded. Without ThinkingPlugin, `<think>` blocks pass through to the channel. The system is designed to work with any subset of its parts — add what you need, leave out what you don't.
+Every built-in plugin is optional. Without PersistencePlugin, messages drop but the daemon doesn't crash. Without CompactionPlugin, history grows unbounded. Without ThinkingPlugin, `<thinking>` blocks pass through to the channel. The system is designed to work with any subset of its parts — add what you need, leave out what you don't.
 
 The agent loop uses single-turn dispatch: one LLM call per queue item. Tool calls become independent async tasks. When a task completes, the result arrives as a notification that feeds back into the queue, triggering the next LLM call. Multi-turn reasoning emerges from this cycle rather than from a blocking loop. This keeps the channel queue responsive — user messages are never stuck behind a long tool chain.
 
@@ -30,7 +30,7 @@ agent:
 ```
 
 ```sh
-corvidae          # reads agent.yaml from cwd
+uv run corvidae          # reads agent.yaml from cwd
 ```
 
 The daemon connects to configured transports, listens for messages, and runs until SIGINT or SIGTERM.
@@ -41,7 +41,7 @@ Clone the repo — corvidae isn't published on PyPI.
 
 ```sh
 uv sync
-corvidae
+uv run corvidae
 ```
 
 For development (includes pytest):
@@ -73,7 +73,7 @@ Key sections:
 - Multi-turn tool-calling loop: tool calls run as async tasks, results trigger the next turn
 - Context window management: estimates token count, compacts (summarizes) when nearing the budget
 - SQLite conversation persistence with an append-only message log
-- `<think>` block handling: stripped from display, optionally retained in DB
+- `<thinking>` block handling: stripped from display, optionally retained in DB
 - MCP (Model Context Protocol) client: connects to external tool servers over stdio or SSE
 - Per-channel config overrides for system prompt, token budget, turn limits, and more
 - Runtime settings tool: the LLM can adjust its own parameters mid-session (with optional immutable keys)
@@ -91,7 +91,7 @@ Key sections:
 | SubagentPlugin | Launches background agents with their own LLM sessions |
 | McpClientPlugin | Connects to external MCP servers and exposes their tools |
 | CompactionPlugin | Summarizes older messages when nearing the token budget |
-| ThinkingPlugin | Strips `<think>` blocks from display, optionally from prompt history |
+| ThinkingPlugin | Strips `<thinking>` blocks from display, optionally from prompt history |
 | RuntimeSettingsPlugin | Lets the LLM adjust its own per-channel parameters mid-session |
 | IdleMonitorPlugin | Fires `on_idle` when all queues are quiescent |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-pythonpath = ["tests"]
+pythonpath = ["tests", "."]
 markers = ["eval: live LLM evaluation tests (deselected by default, run with --run-eval)"]
 filterwarnings = [
     "ignore::DeprecationWarning:chromadb",

--- a/tests/test_turn.py
+++ b/tests/test_turn.py
@@ -79,6 +79,24 @@ def test_tool_to_schema_zero_params():
     assert "required" not in params
 
 
+def test_tool_to_schema_literal_type_produces_enum():
+    """Literal type annotations produce enum constraints in the schema."""
+    from typing import Literal
+
+    async def choose(color: Literal["red", "green", "blue"], reason: str) -> str:
+        """Pick a color."""
+        return color
+
+    schema = tool_to_schema(choose)
+
+    color_prop = schema["function"]["parameters"]["properties"]["color"]
+    assert "enum" in color_prop
+    assert set(color_prop["enum"]) == {"red", "green", "blue"}
+    assert color_prop["type"] == "string"
+    # title should be stripped
+    assert "title" not in color_prop
+
+
 # ---------------------------------------------------------------------------
 # LLMClient extra_body tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
General-purpose improvements that were bundled into the workflow PR (#41) but belong in the main codebase:

- **pyproject.toml**: add `"."` to pythonpath so top-level packages are importable in tests
- **tests/test_turn.py**: add test verifying `Literal` type annotations produce `enum` constraints in tool schemas
- **README.md**: fix `<think` typo → `<thinking>` (3 occurrences), correct run command to `uv run corvidae`
- **.gitignore**: add `.superpowers/` and `eval_results.json`

These are being extracted from PR #41 prior to the workflow tool being moved to its own repo.